### PR TITLE
JPERF-408 Set GC params based on Java version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.10.0...master
+[Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.11.0...master
+
+## [4.11.0] - 2019-03-12
+[4.11.0]: https://github.com/atlassian/infrastructure/compare/release-4.10.0...release-4.11.0
 
 ### Added
 - Set GC params based on Java version. Resolve [JPERF-408].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.10.0...master
 
+### Added
+- Set GC params based on Java version. Resolve [JPERF-408].
+
+[JPERF-408]: https://ecosystem.atlassian.net/browse/JPERF-408
+
 ## [4.10.0] - 2019-03-07
 [4.10.0]: https://github.com/atlassian/infrastructure/compare/release-4.9.0...release-4.10.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/JiraJvmArgs.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/JiraJvmArgs.kt
@@ -13,17 +13,43 @@ class JiraJvmArgs(
         debug: JvmDebug,
         jmx: RemoteJmx,
         jiraIp: String
-    ): List<JvmArg> = listOf(
-        JvmArg("-Datlassian.darkfeature.jira.onboarding.feature.disabled=", "true"),
-        JvmArg("-Djira.startup.warnings.disable=", "true"),
-        JvmArg("-XX:+PrintGCDetails"),
-        JvmArg("-XX:+PrintGCDateStamps"),
-        JvmArg("-XX:+PrintGCTimeStamps"),
-        JvmArg("-XX:+PrintGCCause"),
-        JvmArg("-XX:+PrintTenuringDistribution"),
-        JvmArg("-XX:+PrintGCApplicationStoppedTime"),
-        JvmArg("-XX:+UseGCLogFileRotation"),
-        JvmArg("-XX:NumberOfGCLogFiles=", "5"),
-        JvmArg("-XX:GCLogFileSize=", "20M")
-    ) + debug.getJvmOption() + jmx.getJvmArgs(jiraIp) + extra
+    ): List<JvmArg> = java8Arguments() + debug.getJvmOption() + jmx.getJvmArgs(jiraIp) + extra
+
+    fun arguments(
+        debug: JvmDebug,
+        jmx: RemoteJmx,
+        jiraIp: String,
+        jdkVersion: Int
+    ): List<JvmArg> {
+        val jvmArg = if (jdkVersion > 8) java9Arguments() else java8Arguments()
+        return jvmArg + debug.getJvmOption() + jmx.getJvmArgs(jiraIp) + extra
+    }
+
+    private fun java8Arguments(): List<JvmArg> {
+        return commonArguments() + listOf(
+            JvmArg("-XX:+PrintGCDetails"),
+            JvmArg("-XX:+PrintGCDateStamps"),
+            JvmArg("-XX:+PrintGCTimeStamps"),
+            JvmArg("-XX:+PrintGCCause"),
+            JvmArg("-XX:+PrintTenuringDistribution"),
+            JvmArg("-XX:+PrintGCApplicationStoppedTime"),
+            JvmArg("-XX:+UseGCLogFileRotation"),
+            JvmArg("-XX:NumberOfGCLogFiles=", "5"),
+            JvmArg("-XX:GCLogFileSize=", "20M")
+        )
+    }
+
+    private fun commonArguments(): List<JvmArg> {
+        return listOf(
+            JvmArg("-Datlassian.darkfeature.jira.onboarding.feature.disabled=", "true"),
+            JvmArg("-Djira.startup.warnings.disable=", "true")
+        )
+    }
+
+    private fun java9Arguments(): List<JvmArg> {
+        return commonArguments() + listOf(
+            JvmArg("-Xlog:gc*:file=atlassian-jira-gc-%t.log:time,uptime:filecount=5,filesize=20M")
+        )
+    }
+
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/JiraNodeConfig.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/JiraNodeConfig.kt
@@ -2,6 +2,7 @@ package com.atlassian.performance.tools.infrastructure.api.jira
 
 import com.atlassian.performance.tools.infrastructure.api.jvm.DisabledJvmDebug
 import com.atlassian.performance.tools.infrastructure.api.jvm.JavaDevelopmentKit
+import com.atlassian.performance.tools.infrastructure.api.jvm.VersionedJavaDevelopmentKit
 import com.atlassian.performance.tools.infrastructure.api.jvm.JvmDebug
 import com.atlassian.performance.tools.infrastructure.api.jvm.OracleJDK
 import com.atlassian.performance.tools.infrastructure.api.jvm.jmx.DisabledRemoteJmx
@@ -110,6 +111,7 @@ class JiraNodeConfig private constructor(
         private var splunkForwarder: SplunkForwarder = DisabledSplunkForwarder()
         private var launchTimeouts: JiraLaunchTimeouts = JiraLaunchTimeouts.Builder().build()
         private var jdk: JavaDevelopmentKit = OracleJDK()
+        private var versionedJdk: VersionedJavaDevelopmentKit? = null
         private var profiler: Profiler = DisabledProfiler()
 
         constructor(
@@ -133,6 +135,7 @@ class JiraNodeConfig private constructor(
         fun launchTimeouts(launchTimeouts: JiraLaunchTimeouts) = apply { this.launchTimeouts = launchTimeouts }
         fun collectdConfig(collectdConfigs: List<URI>) = apply { this.collectdConfigs = collectdConfigs }
         fun jdk(jdk: JavaDevelopmentKit) = apply { this.jdk = jdk }
+        fun versionedJdk(versionedJdk: VersionedJavaDevelopmentKit) = apply { this.versionedJdk = versionedJdk }
         fun profiler(profiler: Profiler) = apply { this.profiler = profiler }
 
         fun build() = JiraNodeConfig(
@@ -143,7 +146,7 @@ class JiraNodeConfig private constructor(
             splunkForwarder = splunkForwarder,
             collectdConfigs = collectdConfigs,
             launchTimeouts = launchTimeouts,
-            jdk = jdk,
+            jdk = if (versionedJdk != null) versionedJdk as JavaDevelopmentKit else jdk,
             profiler = profiler
         )
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/SetenvSh.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/SetenvSh.kt
@@ -3,6 +3,7 @@ package com.atlassian.performance.tools.infrastructure.api.jira
 import com.atlassian.performance.tools.infrastructure.api.Sed
 import com.atlassian.performance.tools.infrastructure.api.jira.SetenvSh.Variables.*
 import com.atlassian.performance.tools.infrastructure.api.jvm.JvmArg
+import com.atlassian.performance.tools.infrastructure.api.jvm.VersionedJavaDevelopmentKit
 import com.atlassian.performance.tools.ssh.api.SshConnection
 
 /**
@@ -28,14 +29,17 @@ class SetenvSh(
         gcLog: JiraGcLog,
         jiraIp: String
     ) {
+        val jdkVersion = if (config.jdk is VersionedJavaDevelopmentKit) config.jdk.getMajorVersion() else 8
         val args = config.jvmArgs
         val original = connection.execute("cat ${this.location}").output
         setMemory(connection, args, original)
-        val jvmArgs = args.arguments(
+        var jvmArgs = args.arguments(
             debug = config.debug,
             jmx = config.remoteJmx,
-            jiraIp = jiraIp
-        ) + gcLog.jvmArg()
+            jiraIp = jiraIp,
+            jdkVersion = jdkVersion
+        )
+        if (jdkVersion == 8) jvmArgs += gcLog.jvmArg()
         setArguments(connection, jvmArgs, original)
     }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK.kt
@@ -6,13 +6,15 @@ import com.atlassian.performance.tools.ssh.api.SshConnection
 import java.net.URI
 import java.time.Duration
 
-class AdoptOpenJDK : JavaDevelopmentKit {
+class AdoptOpenJDK : VersionedJavaDevelopmentKit {
     private val jdkVersion = "8u172-b11"
     private val jdkArchive = "OpenJDK8_x64_Linux_jdk$jdkVersion.tar.gz"
     private val jdkUrl = URI("https://github.com/AdoptOpenJDK/openjdk8-releases/releases/download/jdk$jdkVersion/$jdkArchive")
     private val jreBin = "~/jdk$jdkVersion/jre/bin/"
     private val jdkBin = "~/jdk$jdkVersion/bin/"
     override val jstatMonitoring: Jstat = Jstat(jdkBin)
+
+    override fun getMajorVersion() = 8
 
     override fun install(connection: SshConnection) {
         download(connection)

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK11.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK11.kt
@@ -6,7 +6,7 @@ import com.atlassian.performance.tools.ssh.api.SshConnection
 import java.net.URI
 import java.time.Duration
 
-class AdoptOpenJDK11 : JavaDevelopmentKit {
+class AdoptOpenJDK11 : VersionedJavaDevelopmentKit {
     private val jdkVersion = "-11.0.1+13"
     private val jdkArchive = "OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
     /**
@@ -19,6 +19,8 @@ class AdoptOpenJDK11 : JavaDevelopmentKit {
     private val jreBin = "~/jdk$jdkVersion/jre/bin/"
     private val jdkBin = "~/jdk$jdkVersion/bin/"
     override val jstatMonitoring: Jstat = Jstat(jdkBin)
+
+    override fun getMajorVersion() = 11
 
     override fun install(connection: SshConnection) {
         download(connection)

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJDK.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJDK.kt
@@ -5,8 +5,10 @@ import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import java.time.Duration
 
-class OpenJDK : JavaDevelopmentKit {
+class OpenJDK : VersionedJavaDevelopmentKit {
     override val jstatMonitoring: Jstat = Jstat("")
+
+    override fun getMajorVersion() = 8
 
     override fun install(connection: SshConnection) {
         Ubuntu().install(

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJDK11.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJDK11.kt
@@ -5,8 +5,10 @@ import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import java.time.Duration
 
-class OpenJDK11 : JavaDevelopmentKit {
+class OpenJDK11 : VersionedJavaDevelopmentKit {
     override val jstatMonitoring: Jstat = Jstat("")
+
+    override fun getMajorVersion() = 11
 
     override fun install(connection: SshConnection) {
         Ubuntu().install(

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJDK.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJDK.kt
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.Logger
 import java.net.URI
 import java.time.Duration
 
-class OracleJDK : JavaDevelopmentKit {
+class OracleJDK : VersionedJavaDevelopmentKit {
     private val logger: Logger = LogManager.getLogger(this::class.java)
     private val jdkUpdate = 131
     private val jdkArchive = "jdk-8u$jdkUpdate-linux-x64.tar.gz"
@@ -20,6 +20,8 @@ class OracleJDK : JavaDevelopmentKit {
         replaceWith = ReplaceWith("jstatMonitoring")
     )
     val jstat = jstatMonitoring
+
+    override fun getMajorVersion() = 8
 
     override fun install(connection: SshConnection) {
         download(connection)

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/VersionedJavaDevelopmentKit.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/VersionedJavaDevelopmentKit.kt
@@ -1,0 +1,5 @@
+package com.atlassian.performance.tools.infrastructure.api.jvm
+
+interface VersionedJavaDevelopmentKit : JavaDevelopmentKit {
+    fun getMajorVersion(): Int
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.time.Duration
 
 class JstatSupport(
-    private val jdk: JavaDevelopmentKit,
+    private val jdk: VersionedJavaDevelopmentKit,
     private val expectedJstatHeader: String = "Timestamp         S0     S1     E      O      M     CCS    YGC     YGCT    FGC    FGCT     GCT"
 ) {
     private val jarName = "hello-world-after-1m-wait.jar"


### PR DESCRIPTION
To be able to run performance tests for OpenJDK 11 we have to set GC params based on Java version.