### PR TITLE
JPERF-429: Respect `VirtualUserLoad.maxOverallLoad` when spreading lo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.11.0...master
 
+### Added
+- Respect `VirtualUserLoad.maxOverallLoad` when spreading load across `MulticastVirtualUsers`. Fix [JPERF-429].
+
+### Fixed
+- Rely on `virtual-users` to slice the load. Transparently support any future sliceable VU load features.
+
+[JPERF-429]: https://ecosystem.atlassian.net/browse/JPERF-429
+
 ## [4.11.0] - 2019-03-12
 [4.11.0]: https://github.com/atlassian/infrastructure/compare/release-4.10.0...release-4.11.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ configurations.all {
 dependencies {
     api("com.atlassian.performance.tools:ssh:[2.0.0,3.0.0)")
     api("com.atlassian.performance.tools:jira-actions:[2.0.0,4.0.0)")
-    api("com.atlassian.performance.tools:virtual-users:[3.4.0,4.0.0)")
+    api("com.atlassian.performance.tools:virtual-users:[3.5.0,4.0.0)")
 
     implementation("com.atlassian.performance.tools:io:[1.0.0,2.0.0)")
     implementation("com.atlassian.performance.tools:concurrency:[1.0.0,2.0.0)")

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -7,7 +7,7 @@ com.atlassian.performance.tools:jira-actions:3.3.0
 com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -6,7 +6,7 @@ com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.3.0
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.errorprone:error_prone_annotations:2.1.3

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -7,7 +7,7 @@ com.atlassian.performance.tools:jira-actions:3.3.0
 com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -7,7 +7,7 @@ com.atlassian.performance.tools:jira-actions:3.3.0
 com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -7,7 +7,7 @@ com.atlassian.performance.tools:jira-actions:3.3.0
 com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -8,7 +8,7 @@ com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -8,7 +8,7 @@ com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -8,7 +8,7 @@ com.atlassian.performance.tools:jira-software-actions:1.3.1
 com.atlassian.performance.tools:jvm-tasks:1.0.0
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.atlassian.performance.tools:ssh:2.2.0
-com.atlassian.performance.tools:virtual-users:3.4.1
+com.atlassian.performance.tools:virtual-users:3.6.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/virtualusers/MulticastVirtualUsers.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/virtualusers/MulticastVirtualUsers.kt
@@ -1,9 +1,8 @@
 package com.atlassian.performance.tools.infrastructure.api.virtualusers
 
 import com.atlassian.performance.tools.concurrency.api.submitWithLogContext
-import com.atlassian.performance.tools.virtualusers.api.VirtualUserLoad
 import com.atlassian.performance.tools.virtualusers.api.VirtualUserOptions
-import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior.Builder
+import com.atlassian.performance.tools.virtualusers.api.config.VirtualUserBehavior
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import java.util.concurrent.Executors
 
@@ -23,7 +22,7 @@ class MulticastVirtualUsers<out T : VirtualUsers>(
      */
     private fun multicast(
         label: String,
-        operation: (VirtualUsers, Long) -> Unit
+        operation: (VirtualUsers, Int) -> Unit
     ) {
         val executor = Executors.newFixedThreadPool(
             nodes.size,
@@ -35,7 +34,7 @@ class MulticastVirtualUsers<out T : VirtualUsers>(
             .mapIndexed { index, node ->
                 executor.submitWithLogContext("$label $node") {
                     try {
-                        operation(node, index.toLong())
+                        operation(node, index)
                     } catch (e: Exception) {
                         throw Exception("$label failed on $node", e)
                     }
@@ -52,19 +51,13 @@ class MulticastVirtualUsers<out T : VirtualUsers>(
         if (nodeCount > virtualUsers) {
             throw Exception("$virtualUsers virtual users are not enough to spread into $nodeCount nodes")
         }
-        val vusPerNode = virtualUsers / nodeCount
-        val rampPerNode = load.ramp.dividedBy(nodeCount.toLong())
+        val loadSlices = load.slice(nodeCount)
         multicast("apply load") { node, index ->
             node.applyLoad(
                 VirtualUserOptions(
                     target = options.target,
-                    behavior = Builder(options.behavior)
-                        .load(VirtualUserLoad(
-                            virtualUsers = vusPerNode,
-                            hold = load.hold + rampPerNode.multipliedBy(index),
-                            ramp = rampPerNode,
-                            flat = load.flat + rampPerNode.multipliedBy(nodeCount - index - 1)
-                        ))
+                    behavior = VirtualUserBehavior.Builder(options.behavior)
+                        .load(loadSlices[index])
                         .let { if (index > 0) it.skipSetup(true) else it }
                         .build()
                 )


### PR DESCRIPTION
…ad across `MulticastVirtualUsers`

Rely on `virtual-users` to slice the load. Transparently support any future sliceable VU load features.