### PR TITLE
Fix chopped multiline in Travis YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ cache:
     - "$HOME/.gradle/wrapper/"
 notifications:
   slack:
-    secure: 'NCK1FQMSNkSKHnJvj8p0ha+fV+bPfFxhqG3FNRnPioAW+zC05wdM1+9RcAkqxUYvaLpWgLu7kfERh8RKkpN1OPKODqCmGcpUBcRZ+yBtbkJ
-      yL9D1eCkbVJR5Bc9e0WODzc02aAkUNBt0yMGk5ZfEBp2J28jjS4ogff5+T6wsjh6LxvDXFI9ZBHN1wX5bYcllL8WcwmAtqtGijnqU8ZiE++s9bGY+7
-      e7IEeYAQzMjuTgCmI8walzm64iNt647WigQlXT4FsggwnThBBCTKc4xgKmPJMwbOvcvkefVc5Hz+W/wD+iJXgtjx9i6N2qtPT/wpxPRHpDO8OCHT6+
-      z7TMZYh+jV8Cfz10wFOoKDgzODP66Id2r3ofk2qsOiVQpfp2Jeu/o6DA+efcMSM5whWemWN5y0AukCvHO681iviiBPBXJsncQURI0k6qJ3XA217VZN
-      w16WHbqqQpizI3PAWARM0Je4aQgAmBLmWlQQRawmjSOO8f9tZKU2AUlAbtLtI/TPi4m+BJj/AjUNYZJ90LocUrk00HgwnjomKqlQyjix+xf10NH5/J
-      ikEO6OeiIP23/qbxD/f3uXM6MKyD0jK1dcWPT4RhCA7fAjySxx34lHOqtSUXw68Hw/B3pbtTGqPExgXcph70vMUefQvNp7pSY8ER1q1k4zuA4WEBus
-      oD8bgI='
+    secure: "NCK1FQMSNkSKHnJvj8p0ha+fV+bPfFxhqG3FNRnPioAW+zC05wdM1+9RcAkqxUYvaLpWgLu7kfERh8RKkpN1OPKODqCmGcpUBcRZ+yBtbk\
+      JyL9D1eCkbVJR5Bc9e0WODzc02aAkUNBt0yMGk5ZfEBp2J28jjS4ogff5+T6wsjh6LxvDXFI9ZBHN1wX5bYcllL8WcwmAtqtGijnqU8ZiE++s9bGY\
+      +7e7IEeYAQzMjuTgCmI8walzm64iNt647WigQlXT4FsggwnThBBCTKc4xgKmPJMwbOvcvkefVc5Hz+W/wD+iJXgtjx9i6N2qtPT/wpxPRHpDO8OCH\
+      T6+z7TMZYh+jV8Cfz10wFOoKDgzODP66Id2r3ofk2qsOiVQpfp2Jeu/o6DA+efcMSM5whWemWN5y0AukCvHO681iviiBPBXJsncQURI0k6qJ3XA21\
+      7VZNw16WHbqqQpizI3PAWARM0Je4aQgAmBLmWlQQRawmjSOO8f9tZKU2AUlAbtLtI/TPi4m+BJj/AjUNYZJ90LocUrk00HgwnjomKqlQyjix+xf10\
+      NH5/JikEO6OeiIP23/qbxD/f3uXM6MKyD0jK1dcWPT4RhCA7fAjySxx34lHOqtSUXw68Hw/B3pbtTGqPExgXcph70vMUefQvNp7pSY8ER1q1k4zuA\
+      4WEBusoD8bgI="


### PR DESCRIPTION
https://travis-ci.com/atlassian/infrastructure/jobs/192189041/config failed and did not notify on Slack.
I used http://www.yamllint.com/ to parse the YAML and it turns out the current multiline syntax adds spaces on every new line. I used the same linter to check the fixed version.