### PR TITLE
QUICK-224 deprecate the use of strings to hold and transfer jira licenses

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysql.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysql.kt
@@ -2,7 +2,14 @@ package com.atlassian.performance.tools.infrastructure.api.database
 
 import com.atlassian.performance.tools.infrastructure.database.SshMysqlClient
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.io.File
 import java.net.URI
+import java.nio.file.Files
+import java.io.FileWriter
+import java.io.BufferedWriter
+
 
 /**
  * Removes all licenses from [database] and adds [licenses] instead.
@@ -10,10 +17,18 @@ import java.net.URI
  * @param [database] must be MySQL
  * @since 4.13.0
  */
-class LicenseOverridingMysql(
+class LicenseOverridingMysql private constructor(
     private val database: Database,
-    private val licenses: List<String>
+    private val licenseCollection: LicenseCollection
 ) : Database {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    @Deprecated(message = "Use the Builder and pass licenses as Files to reduce accidental leakage of the license")
+    constructor(
+        database: Database,
+        licenses: List<String>) : this(database, LicenseCollection(licenses.map<String, File> {
+        createTempLicenseFile(it)
+    }))
 
     override fun setup(
         ssh: SshConnection
@@ -24,16 +39,53 @@ class LicenseOverridingMysql(
         ssh: SshConnection
     ) {
         database.start(jira, ssh)
-        val firstLicense = licenses.first()
         val licenseTable = "jiradb.productlicense"
-        val sql = "DELETE FROM $licenseTable; REPLACE INTO $licenseTable (LICENSE) VALUES (\"$firstLicense\");"
-        val mysql = SshMysqlClient()
-        mysql.runSql(ssh, sql)
-        licenses.drop(1).forEach { license ->
-            mysql.runSql(
-                ssh = ssh,
-                sql = "INSERT INTO $licenseTable SELECT MAX(id)+1, \"$license\" FROM $licenseTable;"
+        val client = SshMysqlClient()
+        client.runSql(ssh, "DELETE FROM $licenseTable;")
+        logger.info("Licenses nuked")
+        licenseCollection.licenses.forEachIndexed { index, license ->
+            val flatLicenseText = license.readLines().joinToString(separator = "") { it.trim() }
+            val insert = "INSERT INTO $licenseTable VALUES ($index, \"$flatLicenseText\");"
+            val insertFile = Files.createTempFile("license-insert", ".sql").toFile()
+            insertFile.deleteOnExit()
+            insertFile
+                .bufferedWriter()
+                .use { it.write(insert) }
+            client.runSql(ssh, insertFile)
+            insertFile.delete()
+            logger.info("Added license: ${flatLicenseText.substring(0..8)}...")
+        }
+    }
+
+    private class LicenseCollection(
+        val licenses: List<File>
+    )
+
+    class Builder(private val database: Database) {
+        private var licenseFiles: List<File> = emptyList()
+
+        @Deprecated(message = "Pass licenses as Files to reduce accidental leakage of the license")
+        fun licenseStrings(licenses: List<String>) = apply {
+            this.licenseFiles = licenses.map {
+                createTempLicenseFile(it)
+            }
+        }
+
+        fun licenseFiles(licenses: List<File>) = apply { this.licenseFiles = licenses }
+
+        fun build(): LicenseOverridingMysql {
+            return LicenseOverridingMysql(
+                database = database,
+                licenseCollection = LicenseCollection(licenseFiles)
             )
         }
     }
+}
+
+fun createTempLicenseFile(license: String): File {
+    val licenseFile = File.createTempFile("jira-license", ".txt")
+    val bw = BufferedWriter(FileWriter(licenseFile))
+    bw.write(license)
+    bw.close()
+    return licenseFile
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClient.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClient.kt
@@ -1,15 +1,27 @@
 package com.atlassian.performance.tools.infrastructure.database
 
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.io.File
 
-internal class SshMysqlClient {
+internal class SshMysqlClient : SshSqlClient {
 
-    fun runSql(
+    override fun runSql(
         ssh: SshConnection,
         sql: String
     ): SshConnection.SshResult {
         val quotedSql = sql.quote('"')
         return ssh.execute("mysql -h 127.0.0.1 -u root -e $quotedSql")
+    }
+
+    override fun runSql(
+        ssh: SshConnection,
+        sql: File
+    ): SshConnection.SshResult {
+        val remoteSqlFile = sql.name
+        ssh.upload(sql, remoteSqlFile)
+        val result = ssh.execute("mysql -h 127.0.0.1 -u root < $remoteSqlFile")
+        ssh.execute("rm $remoteSqlFile")
+        return result
     }
 
     private fun String.quote(

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshSqlClient.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshSqlClient.kt
@@ -1,0 +1,17 @@
+package com.atlassian.performance.tools.infrastructure.database
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.io.File
+
+interface SshSqlClient {
+
+    fun runSql(
+        ssh: SshConnection,
+        sql: String
+    ): SshConnection.SshResult
+
+    fun runSql(
+        ssh: SshConnection,
+        sql: File
+    ): SshConnection.SshResult
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysqlTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysqlTest.kt
@@ -1,13 +1,11 @@
 package com.atlassian.performance.tools.infrastructure.api.database
 
-import com.atlassian.performance.tools.infrastructure.mock.UnimplementedSshConnection
+import com.atlassian.performance.tools.infrastructure.mock.ExecutionRememberingSshConnection
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import com.atlassian.performance.tools.ssh.api.SshConnection.SshResult
-import org.apache.logging.log4j.Level
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.io.File
 import java.net.URI
-import java.time.Duration
 
 class LicenseOverridingMysqlTest {
 
@@ -15,55 +13,150 @@ class LicenseOverridingMysqlTest {
 
     @Test
     fun shouldOverrideOneLicense() {
-        val (testedDatabase, underlyingDatabase, ssh) = setUp(listOf("the only license"))
+        val licenseStrings = listOf("the only license")
+        val (testedDatabase, underlyingDatabase, ssh) = setUp(licenseStrings)
 
         testedDatabase.start(jira, ssh)
 
         assertThat(underlyingDatabase.started)
             .`as`("underlying database started")
             .isTrue()
+
         assertSshCommands(
             ssh,
-            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense; REPLACE INTO jiradb.productlicense (LICENSE) VALUES (\"the only license\");""""
+            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense;"""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[0].remoteDestination}""",
+            """rm ${ssh.uploads[0].remoteDestination}"""
         )
+
+        assertSshUploads(ssh, licenseStrings)
     }
 
     @Test
     fun shouldOverrideTwoLicenses() {
-        val (testedDatabase, _, ssh) = setUp(listOf("the first license", "the second license"))
+        val licenseStrings = listOf("the first license", "the second license")
+        val (testedDatabase, _, ssh) = setUp(licenseStrings)
 
         testedDatabase.start(jira, ssh)
 
         assertSshCommands(
             ssh,
-            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense; REPLACE INTO jiradb.productlicense (LICENSE) VALUES (\"the first license\");"""",
-            """mysql -h 127.0.0.1 -u root -e "INSERT INTO jiradb.productlicense SELECT MAX(id)+1, \"the second license\" FROM jiradb.productlicense;""""
+            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense;"""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[0].remoteDestination}""",
+            """rm ${ssh.uploads[0].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[1].remoteDestination}""",
+            """rm ${ssh.uploads[1].remoteDestination}"""
         )
+
+        assertSshUploads(ssh, licenseStrings)
     }
 
     @Test
     fun shouldOverrideThreeLicenses() {
-        val (testedDatabase, _, ssh) = setUp(listOf("the first license", "the second license", "the third license"))
+        val licenseStrings = listOf("the first license", "the second license", "the third license")
+        val (testedDatabase, _, ssh) = setUp(licenseStrings)
 
         testedDatabase.start(jira, ssh)
 
         assertSshCommands(
             ssh,
-            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense; REPLACE INTO jiradb.productlicense (LICENSE) VALUES (\"the first license\");"""",
-            """mysql -h 127.0.0.1 -u root -e "INSERT INTO jiradb.productlicense SELECT MAX(id)+1, \"the second license\" FROM jiradb.productlicense;"""",
-            """mysql -h 127.0.0.1 -u root -e "INSERT INTO jiradb.productlicense SELECT MAX(id)+1, \"the third license\" FROM jiradb.productlicense;""""
+            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense;"""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[0].remoteDestination}""",
+            """rm ${ssh.uploads[0].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[1].remoteDestination}""",
+            """rm ${ssh.uploads[1].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[2].remoteDestination}""",
+            """rm ${ssh.uploads[2].remoteDestination}"""
         )
+
+        assertSshUploads(ssh, licenseStrings)
+    }
+
+    @Test
+    fun shouldOverrideThreeLicensesFromFilesUsingBuilder() {
+        val licenseStrings = listOf("the first license", "the second license", "the third license")
+
+        val licenseFiles = licenseStrings.map { createTempLicenseFile(it) }
+
+        val (testedDatabase, _, ssh) = setUpWithLicenseFiles(licenseFiles)
+
+        testedDatabase.start(jira, ssh)
+
+        assertSshCommands(
+            ssh,
+            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense;"""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[0].remoteDestination}""",
+            """rm ${ssh.uploads[0].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[1].remoteDestination}""",
+            """rm ${ssh.uploads[1].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[2].remoteDestination}""",
+            """rm ${ssh.uploads[2].remoteDestination}"""
+        )
+
+        assertSshUploads(ssh, licenseStrings)
+    }
+
+    @Test
+    fun shouldOverrideThreeLicensesFromStringUsingBuilder() {
+        val licenseStrings = listOf("the first license", "the second license", "the third license")
+
+        val (testedDatabase, _, ssh) = setUpWithLicenseStrings(licenseStrings)
+
+        testedDatabase.start(jira, ssh)
+
+        assertSshCommands(
+            ssh,
+            """mysql -h 127.0.0.1 -u root -e "DELETE FROM jiradb.productlicense;"""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[0].remoteDestination}""",
+            """rm ${ssh.uploads[0].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[1].remoteDestination}""",
+            """rm ${ssh.uploads[1].remoteDestination}""",
+            """mysql -h 127.0.0.1 -u root < ${ssh.uploads[2].remoteDestination}""",
+            """rm ${ssh.uploads[2].remoteDestination}"""
+        )
+
+        assertSshUploads(ssh, licenseStrings)
     }
 
     private fun setUp(
         licenses: List<String>
     ): DatabaseStartTest {
         val underlyingDatabase = RememberingDatabase()
+        @Suppress("DEPRECATION")
         return DatabaseStartTest(
             testedDatabase = LicenseOverridingMysql(
                 database = underlyingDatabase,
                 licenses = licenses
             ),
+            underlyingDatabase = underlyingDatabase,
+            ssh = ExecutionRememberingSshConnection()
+        )
+    }
+
+    private fun setUpWithLicenseFiles(
+        licenses: List<File>
+    ): DatabaseStartTest {
+        val underlyingDatabase = RememberingDatabase()
+        return DatabaseStartTest(
+            testedDatabase = LicenseOverridingMysql
+                .Builder(underlyingDatabase)
+                .licenseFiles(licenses)
+                .build(),
+            underlyingDatabase = underlyingDatabase,
+            ssh = ExecutionRememberingSshConnection()
+        )
+    }
+
+    private fun setUpWithLicenseStrings(
+        licenses: List<String>
+    ): DatabaseStartTest {
+        val underlyingDatabase = RememberingDatabase()
+        @Suppress("DEPRECATION")
+        return DatabaseStartTest(
+            testedDatabase = LicenseOverridingMysql
+                .Builder(underlyingDatabase)
+                .licenseStrings(licenses)
+                .build(),
             underlyingDatabase = underlyingDatabase,
             ssh = ExecutionRememberingSshConnection()
         )
@@ -76,6 +169,22 @@ class LicenseOverridingMysqlTest {
         assertThat(ssh.commands)
             .`as`("SSH commands")
             .containsExactly(*expectedSshCommands)
+    }
+
+    private fun assertSshUploads(ssh: ExecutionRememberingSshConnection, licenseStrings: List<String>) {
+
+        assertThat(ssh.uploads.map { it.content })
+            .`as`("SSH upload content")
+            .containsExactly(*licenseStrings
+                .mapIndexed { i, c ->
+                    """INSERT INTO jiradb.productlicense VALUES ($i, "$c");""" }
+                .toTypedArray())
+
+        ssh.uploads.forEach {
+            assertThat(it.remoteDestination)
+                .`as`("SSH upload files")
+                .isEqualTo(it.localSource.name)
+        }
     }
 
     private data class DatabaseStartTest(
@@ -96,25 +205,6 @@ class LicenseOverridingMysqlTest {
 
         override fun start(jira: URI, ssh: SshConnection) {
             started = true
-        }
-    }
-
-    private class ExecutionRememberingSshConnection : SshConnection by UnimplementedSshConnection() {
-
-        val commands = mutableListOf<String>()
-
-        override fun execute(
-            cmd: String,
-            timeout: Duration,
-            stdout: Level,
-            stderr: Level
-        ): SshResult {
-            commands.add(cmd)
-            return SshResult(
-                exitStatus = 0,
-                output = "",
-                errorOutput = ""
-            )
         }
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClientTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClientTest.kt
@@ -1,0 +1,41 @@
+package com.atlassian.performance.tools.infrastructure.database
+
+
+import com.atlassian.performance.tools.infrastructure.mock.ExecutionRememberingSshConnection
+import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import java.nio.file.Files
+
+
+class SshMysqlClientTest {
+
+    @Test
+    fun shouldRunMySqlCommand() {
+        val client = SshMysqlClient()
+        val ssh = ExecutionRememberingSshConnection()
+        val command = "select * from table"
+        client.runSql(ssh, command)
+
+        assertThat(ssh.commands)
+                .`as`("SSH commands")
+                .containsExactly(
+                        "mysql -h 127.0.0.1 -u root -e \"$command\""
+                )
+    }
+
+    @Test
+    fun shouldRunMySqlCommandFromFile() {
+        val client = SshMysqlClient()
+        val ssh = ExecutionRememberingSshConnection()
+        val file = Files.createTempFile("SshMysqlClientTest", ".txt").toFile()
+        file.writeText("anything we want, as we aren't checking this")
+        client.runSql(ssh, file)
+
+        assertThat(ssh.commands)
+                .`as`("SSH commands")
+                .containsExactly(
+                        "mysql -h 127.0.0.1 -u root < ${file.name}",
+                        "rm ${file.name}"
+                )
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/mock/ExecutionRememberinSshConnection.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/mock/ExecutionRememberinSshConnection.kt
@@ -1,0 +1,34 @@
+package com.atlassian.performance.tools.infrastructure.mock
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.Level
+import java.io.File
+import java.time.Duration
+
+class ExecutionRememberingSshConnection : SshConnection by UnimplementedSshConnection() {
+
+    val commands = mutableListOf<String>()
+    val uploads = mutableListOf<Upload>()
+
+    override fun upload(localSource: File,
+                        remoteDestination: String)
+    {
+        uploads.add(Upload(localSource, remoteDestination, localSource.readText() ))
+    }
+
+    override fun execute(
+        cmd: String,
+        timeout: Duration,
+        stdout: Level,
+        stderr: Level
+    ): SshConnection.SshResult {
+        commands.add(cmd)
+        return SshConnection.SshResult(
+            exitStatus = 0,
+            output = "",
+            errorOutput = ""
+        )
+    }
+
+    class Upload(val localSource: File, val remoteDestination: String, val content: String)
+}


### PR DESCRIPTION
Pulls in code that was first implemented as workarounds/improvements in https://github.com/atlassian/jira-hardware-exploration