### PR TITLE
JPERF-523 deprecate the use of strings to hold and transfer jira licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.13.0...master
 
+### Deprecated
+- Deprecate the handling of licenses as strings within `LicenseOverridingMysql`. Avoid [JPERF-523].
+
+### Fixed
+- Handle Jira license data as files within `LicenseOverridingMysql`. Fix [JPERF-523].
+
+
+[JPERF-523]: https://ecosystem.atlassian.net/browse/JPERF-523
+
 ## [4.13.0] - 2019-07-05
 [4.13.0]: https://github.com/atlassian/infrastructure/compare/release-4.12.6...release-4.13.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysql.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/LicenseOverridingMysql.kt
@@ -2,7 +2,14 @@ package com.atlassian.performance.tools.infrastructure.api.database
 
 import com.atlassian.performance.tools.infrastructure.database.SshMysqlClient
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.io.File
 import java.net.URI
+import java.nio.file.Files
+import java.io.FileWriter
+import java.io.BufferedWriter
+
 
 /**
  * Removes all licenses from [database] and adds [licenses] instead.
@@ -10,10 +17,18 @@ import java.net.URI
  * @param [database] must be MySQL
  * @since 4.13.0
  */
-class LicenseOverridingMysql(
+class LicenseOverridingMysql private constructor(
     private val database: Database,
-    private val licenses: List<String>
+    private val licenseCollection: LicenseCollection
 ) : Database {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    @Deprecated(message = "Use the Builder and pass licenses as Files to reduce accidental leakage of the license")
+    constructor(
+        database: Database,
+        licenses: List<String>) : this(database, LicenseCollection(licenses.map<String, File> {
+        createTempLicenseFile(it)
+    }))
 
     override fun setup(
         ssh: SshConnection
@@ -24,16 +39,54 @@ class LicenseOverridingMysql(
         ssh: SshConnection
     ) {
         database.start(jira, ssh)
-        val firstLicense = licenses.first()
         val licenseTable = "jiradb.productlicense"
-        val sql = "DELETE FROM $licenseTable; REPLACE INTO $licenseTable (LICENSE) VALUES (\"$firstLicense\");"
-        val mysql = SshMysqlClient()
-        mysql.runSql(ssh, sql)
-        licenses.drop(1).forEach { license ->
-            mysql.runSql(
-                ssh = ssh,
-                sql = "INSERT INTO $licenseTable SELECT MAX(id)+1, \"$license\" FROM $licenseTable;"
+        val client = SshMysqlClient()
+        client.runSql(ssh, "DELETE FROM $licenseTable;")
+        logger.info("Licenses nuked")
+        licenseCollection.licenses.forEachIndexed { index, license ->
+            val flatLicenseText = license.readLines().joinToString(separator = "") { it.trim() }
+            val insert = "INSERT INTO $licenseTable VALUES ($index, \"$flatLicenseText\");"
+            val insertFile = Files.createTempFile("license-insert", ".sql").toFile()
+            insertFile.deleteOnExit()
+            insertFile
+                .bufferedWriter()
+                .use { it.write(insert) }
+            client.runSql(ssh, insertFile)
+            insertFile.delete()
+            logger.info("Added license: ${flatLicenseText.substring(0..8)}...")
+        }
+    }
+
+    private class LicenseCollection(
+        val licenses: List<File>
+    )
+
+    class Builder(private val database: Database) {
+        private var licenseFiles: List<File> = emptyList()
+
+        @Deprecated(message = "Pass licenses as Files to reduce accidental leakage of the license")
+        fun licenseStrings(licenses: List<String>) = apply {
+            this.licenseFiles = licenses.map {
+                createTempLicenseFile(it)
+            }
+        }
+
+        fun licenseFiles(licenses: List<File>) = apply { this.licenseFiles = licenses }
+
+        fun build(): LicenseOverridingMysql {
+            return LicenseOverridingMysql(
+                database = database,
+                licenseCollection = LicenseCollection(licenseFiles)
             )
         }
     }
+}
+
+internal fun createTempLicenseFile(license: String): File {
+    val licenseFile = File.createTempFile("jira-license", ".txt")
+    licenseFile
+        .bufferedWriter()
+        .use { it.write(license) }
+    return licenseFile
+
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClient.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClient.kt
@@ -1,15 +1,27 @@
 package com.atlassian.performance.tools.infrastructure.database
 
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.io.File
 
-internal class SshMysqlClient {
+internal class SshMysqlClient : SshSqlClient {
 
-    fun runSql(
+    override fun runSql(
         ssh: SshConnection,
         sql: String
     ): SshConnection.SshResult {
         val quotedSql = sql.quote('"')
         return ssh.execute("mysql -h 127.0.0.1 -u root -e $quotedSql")
+    }
+
+    override fun runSql(
+        ssh: SshConnection,
+        sql: File
+    ): SshConnection.SshResult {
+        val remoteSqlFile = sql.name
+        ssh.upload(sql, remoteSqlFile)
+        val result = ssh.execute("mysql -h 127.0.0.1 -u root < $remoteSqlFile")
+        ssh.execute("rm $remoteSqlFile")
+        return result
     }
 
     private fun String.quote(

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshSqlClient.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/SshSqlClient.kt
@@ -1,0 +1,17 @@
+package com.atlassian.performance.tools.infrastructure.database
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.io.File
+
+interface SshSqlClient {
+
+    fun runSql(
+        ssh: SshConnection,
+        sql: String
+    ): SshConnection.SshResult
+
+    fun runSql(
+        ssh: SshConnection,
+        sql: File
+    ): SshConnection.SshResult
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClientTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/database/SshMysqlClientTest.kt
@@ -1,0 +1,43 @@
+package com.atlassian.performance.tools.infrastructure.database
+
+
+import com.atlassian.performance.tools.infrastructure.mock.RememberingSshConnection
+import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import java.nio.file.Files
+
+
+class SshMysqlClientTest {
+
+    @Test
+    fun shouldRunMySqlCommand() {
+        val client = SshMysqlClient()
+        val ssh = RememberingSshConnection()
+        val command = "select * from table"
+
+        client.runSql(ssh, command)
+
+        assertThat(ssh.commands)
+                .`as`("SSH commands")
+                .containsExactly(
+                        "mysql -h 127.0.0.1 -u root -e \"$command\""
+                )
+    }
+
+    @Test
+    fun shouldRunMySqlCommandFromFile() {
+        val client = SshMysqlClient()
+        val ssh = RememberingSshConnection()
+        val file = Files.createTempFile("SshMysqlClientTest", ".txt").toFile()
+        file.writeText("anything we want, as we aren't checking this")
+
+        client.runSql(ssh, file)
+
+        assertThat(ssh.commands)
+                .`as`("SSH commands")
+                .containsExactly(
+                        "mysql -h 127.0.0.1 -u root < ${file.name}",
+                        "rm ${file.name}"
+                )
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/mock/RememberinSshConnection.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/mock/RememberinSshConnection.kt
@@ -1,0 +1,34 @@
+package com.atlassian.performance.tools.infrastructure.mock
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.Level
+import java.io.File
+import java.time.Duration
+
+class RememberingSshConnection : SshConnection by UnimplementedSshConnection() {
+
+    val commands = mutableListOf<String>()
+    val uploads = mutableListOf<Upload>()
+
+    override fun upload(localSource: File,
+                        remoteDestination: String)
+    {
+        uploads.add(Upload(localSource, remoteDestination, localSource.readText() ))
+    }
+
+    override fun execute(
+        cmd: String,
+        timeout: Duration,
+        stdout: Level,
+        stderr: Level
+    ): SshConnection.SshResult {
+        commands.add(cmd)
+        return SshConnection.SshResult(
+            exitStatus = 0,
+            output = "",
+            errorOutput = ""
+        )
+    }
+
+    class Upload(val localSource: File, val remoteDestination: String, val content: String)
+}


### PR DESCRIPTION
This effectively pulls in improvements first implemented in 

- https://github.com/atlassian/jira-hardware-exploration/blob/master/src/test/kotlin/com/atlassian/performance/tools/lib/SshMysqlClient.kt
- https://github.com/atlassian/jira-hardware-exploration/blob/c3af5a3254bd71f77febf8e6d0d747fa88880bc1/src/test/kotlin/com/atlassian/performance/tools/lib/LicenseOverridingDatabase.kt

