### PR TITLE
JPERF-619: Reduce max `Ubuntu.install` backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.17.1...master
 
+### Fixed
+- Reduce max `Ubuntu.install` backoff from 1270 seconds to 105 seconds. Fix [JPERF-619].
+- Change `Ubuntu.install` backoff from exponential to static + jitter.
+
+[JPERF-619]: https://ecosystem.atlassian.net/browse/JPERF-619
+
 ## [4.17.1] - 2020-08-27
 [4.17.1]: https://github.com/atlassian/infrastructure/compare/release-4.17.0...release-4.17.1
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 
     implementation("com.atlassian.performance.tools:io:[1.0.0,2.0.0)")
     implementation("com.atlassian.performance.tools:concurrency:[1.0.0,2.0.0)")
-    implementation("com.atlassian.performance.tools:jvm-tasks:[1.0.0,2.0.0)")
+    implementation("com.atlassian.performance.tools:jvm-tasks:[1.2.0, 2.0.0)")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     implementation("com.google.guava:guava:23.6-jre")
     implementation("org.apache.httpcomponents:httpclient:4.5.5")

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -5,7 +5,7 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.9.0
 com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.0.1
+com.atlassian.performance.tools:jvm-tasks:1.2.0
 com.atlassian.performance.tools:ssh-ubuntu:0.2.2
 com.atlassian.performance.tools:ssh:2.3.0
 com.atlassian.performance.tools:virtual-users:3.10.0

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/os/Ubuntu.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/os/Ubuntu.kt
@@ -1,12 +1,15 @@
 package com.atlassian.performance.tools.infrastructure.api.os
 
 import com.atlassian.performance.tools.infrastructure.Iostat
-import com.atlassian.performance.tools.jvmtasks.api.ExponentialBackoff
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
+import com.atlassian.performance.tools.jvmtasks.api.JitterBackoff
+import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
+import com.atlassian.performance.tools.jvmtasks.api.plus
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import net.jcip.annotations.ThreadSafe
 import org.apache.logging.log4j.Level
 import java.time.Duration
+import java.time.Duration.ofSeconds
 import java.util.concurrent.ConcurrentHashMap
 
 @ThreadSafe
@@ -30,9 +33,7 @@ class Ubuntu {
         }
             .retry(
                 maxAttempts = 7, //we need to accommodate cron-based image updates happening in the background
-                backoff = ExponentialBackoff(
-                    baseBackoff = Duration.ofSeconds(5)
-                )
+                backoff = StaticBackoff(ofSeconds(10)) + JitterBackoff(ofSeconds(5))
             )
     }
 

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69IT.kt
@@ -1,8 +1,8 @@
 package com.atlassian.performance.tools.infrastructure.api.browser.chromium
 
-import com.atlassian.performance.tools.infrastructure.api.jvm.StaticBackoff
 import com.atlassian.performance.tools.infrastructure.toSsh
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
+import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.hamcrest.Matchers

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
@@ -1,7 +1,7 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.jvmtasks.api.Backoff
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
+import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import org.assertj.core.api.Assertions
 import java.time.Duration
@@ -38,10 +38,4 @@ class ThreadDumpTest {
             .first()
             .toInt()
     }
-}
-
-internal class StaticBackoff(
-    private val backOff: Duration
-) : Backoff {
-    override fun backOff(attempt: Int): Duration = backOff
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/browser/SshChromium.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/browser/SshChromium.kt
@@ -1,7 +1,7 @@
 package com.atlassian.performance.tools.infrastructure.browser
 
-import com.atlassian.performance.tools.infrastructure.api.jvm.StaticBackoff
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
+import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
 import com.atlassian.performance.tools.ssh.api.DetachedProcess
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import com.atlassian.performance.tools.virtualusers.api.browsers.Browser


### PR DESCRIPTION
There's still 7 retries of `Ubuntu` install.
Exponential backoff with base 5 seconds and exponent of two meant that the 7th attempt took 640 seconds.
Sum of all 7 attempts took 1270 seconds max.
Now the backoff is 5 seconds + jitter between 0 and 10 seconds. Max of 15 seconds per attempt.
Sum of all 7 attempts now takes 105 seconds max.