### PR TITLE
JPERF-664 Use existing package for docker install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.17.3...master
 
+### Fixed
++ Bump version of the docker to `5:19.03.13`. Fix [JPERF-664]
+
+[JPERF-664]: https://ecosystem.atlassian.net/browse/JPERF-664
+
 ## [4.17.3] - 2020-11-25
 [4.17.3]: https://github.com/atlassian/infrastructure/compare/release-4.17.2...release-4.17.3
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/Docker.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/Docker.kt
@@ -28,7 +28,7 @@ internal class Docker {
         val release = ubuntu.getDistributionCodename(ssh)
         ubuntu.addRepository(ssh, "deb [arch=amd64] https://download.docker.com/linux/ubuntu $release stable", "docker");
 
-        val version = "5:19.03.8~3-0~ubuntu-$release"
+        val version = "5:19.03.13~3-0~ubuntu-$release"
         ubuntu.install(
             ssh = ssh,
             packages = listOf("docker-ce=$version"),


### PR DESCRIPTION
Docker.kt was using package that apt-get couldn't find `apt list -a docker` revealed that there is in fact that package, but only with specific version.

Bumping the version solved the problem.