### PR TITLE
Fix tests on WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.17.5...master
 
+### Fixed
+- Increase network-level retries for Jira/browser downloads. Decrease flakiness of such downloads on Ubuntu on WSL2.
+
 ## [4.17.5] - 2020-12-15
 [4.17.5]: https://github.com/atlassian/infrastructure/compare/release-4.17.4...release-4.17.5
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/HttpResource.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/HttpResource.kt
@@ -27,7 +27,7 @@ class HttpResource(
     ) {
         Ubuntu().install(ssh, listOf("lftp"), Duration.ofMinutes(2))
         ssh.execute(
-            """lftp -c 'set net:timeout 15; set net:max-retries 10; pget -n 32 -c "$uri" -o $destination'""",
+            """lftp -c 'set net:timeout 15; set net:max-retries 50; pget -n 32 -c "$uri" -o $destination'""",
             timeout
         )
     }


### PR DESCRIPTION
Fix errors, when running integration tests on Windows Subsystem for Linux:
```
java.lang.Exception: Error while executing lftp -c 'set net:timeout 15; set net:max-retries 10; pget -n 32 -c "https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-7.2.0.tar.gz" -o test/atlassian-jira-software-7.2.0.tar.gz'. Exit status code SshResult(exitStatus=1, output=, errorOutput=pget: /software/jira/downloads/atlassian-jira-software-7.2.0.tar.gz: Fatal error: max-retries exceeded)
```