### PR TITLE
JPERF-732: Download ChromeDriver version that matches installed Chrome version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ Progress on [JPERF-273]:
 
 ### Fixed
 - Increase network-level retries for Jira/browser downloads. Decrease flakiness of such downloads on Ubuntu on WSL2.
+- Download ChromeDriver version that matches installed Chrome version. Fix [JPERF-732].
 
 [JPERF-273]: https://ecosystem.atlassian.net/browse/JPERF-273
+[JPERF-732]: https://ecosystem.atlassian.net/browse/JPERF-732
 
 ## [4.17.5] - 2020-12-15
 [4.17.5]: https://github.com/atlassian/infrastructure/compare/release-4.17.4...release-4.17.5

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromedriverInstaller.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromedriverInstaller.kt
@@ -2,6 +2,8 @@ package com.atlassian.performance.tools.infrastructure
 
 import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClients
 import java.net.URI
 import java.time.Duration
 
@@ -19,5 +21,15 @@ internal class ChromedriverInstaller(private val uri: URI) {
                 Ubuntu().install(ssh, listOf("zip", "libglib2.0-0", "libnss3"), Duration.ofMinutes(2))
             }
         )
+    }
+
+    companion object {
+        fun getLatestVersion(minorVersion: String?): String {
+            val httpclient = HttpClients.createDefault()
+            val versionSuffix = if (minorVersion != null) "_$minorVersion" else "";
+            val get = HttpGet("https://chromedriver.storage.googleapis.com/LATEST_RELEASE$versionSuffix")
+            val response = httpclient.execute(get)
+            return response.entity.content.bufferedReader().use { it.readLine() }
+        }
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/Chrome.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/Chrome.kt
@@ -1,11 +1,8 @@
 package com.atlassian.performance.tools.infrastructure.api.browser
 
 import com.atlassian.performance.tools.infrastructure.ChromedriverInstaller
-import com.atlassian.performance.tools.infrastructure.ParallelExecutor
 import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
 import java.net.URI
 import java.time.Duration.ofMinutes
 
@@ -19,19 +16,16 @@ class Chrome : Browser {
     override fun install(ssh: SshConnection) {
         ubuntu.addKey(ssh, "78BD65473CB3BD13")
         ubuntu.addRepository(ssh, "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main", "google-chrome")
-        ParallelExecutor().execute(
-            { Ubuntu().install(ssh, listOf("google-chrome-stable"), ofMinutes(5)) },
-            {
-                val version = getLatestVersion()
-                ChromedriverInstaller(URI("https://chromedriver.storage.googleapis.com/$version/chromedriver_linux64.zip")).install(ssh)
-            }
-        )
+        Ubuntu().install(ssh, listOf("google-chrome-stable"), ofMinutes(5))
+        val installedMinorVersion = getInstalledMinorVersion(ssh)
+
+        val version = ChromedriverInstaller.getLatestVersion(installedMinorVersion)
+        ChromedriverInstaller(URI("https://chromedriver.storage.googleapis.com/$version/chromedriver_linux64.zip")).install(ssh)
+
     }
 
-    private fun getLatestVersion(): String {
-        val httpclient = HttpClients.createDefault()
-        val get = HttpGet("https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
-        val response = httpclient.execute(get)
-        return response.entity.content.bufferedReader().use { it.readLine() }
+    private fun getInstalledMinorVersion(ssh: SshConnection): String? {
+        val versionString = ssh.execute("/usr/bin/google-chrome --version").output
+        return Regex("Google Chrome ([0-9]+\\.[0-9]+\\.[0-9]+)\\.[0-9]+").find(versionString)?.groupValues?.getOrNull(1)
     }
 }


### PR DESCRIPTION
This is to avoid installing incompatible versions of ChromeDriver and Chrome. For example at the moment, latest ChromeDriver is v90 which requires Chrome v90 which hasn't been released yet.