### PR TITLE
PERF-750: remove reference to jira-soke-tests-eu-s3 bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
+### Security
+- Remove `jira-soke-tests-eu` AWS S3 bucket reference
+
+[JPERF-750]: https://ecosystem.atlassian.net/browse/JPERF-750
 
 ## [4.19.0] - 2022-01-17
 [4.19.0]: https://github.com/atlassian/infrastructure/compare/release-4.18.0...release-4.19.0

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/dataset/ObsoleteHttpDatasetPackage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/dataset/ObsoleteHttpDatasetPackage.kt
@@ -1,12 +1,7 @@
 package com.atlassian.performance.tools.infrastructure.dataset
 
 import com.atlassian.performance.tools.infrastructure.api.dataset.DatasetPackage
-import com.atlassian.performance.tools.infrastructure.api.dataset.FileArchiver
-import com.atlassian.performance.tools.jvmtasks.api.ExponentialBackoff
-import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
-import com.atlassian.performance.tools.jvmtasks.api.TaskTimer
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import java.net.URI
 import java.time.Duration
 
 @Deprecated("The adapter can be removed with a major release.")
@@ -16,21 +11,13 @@ internal class ObsoleteHttpDatasetPackage(
     private val downloadTimeout: Duration
 ) : DatasetPackage {
 
-    private val datasetBucket = URI("https://s3.eu-central-1.amazonaws.com/jira-soke-tests-eu/")
-
     override fun download(
         ssh: SshConnection
     ): String {
-        val unzipCommand = FileArchiver().pipeUnzip(ssh)
-        TaskTimer.time("download") {
-            IdempotentAction("download dataset") {
-                ssh.execute("wget -qO - ${datasetBucket.resolve(downloadPath)} | $unzipCommand", downloadTimeout)
-            }.retry(5, ExponentialBackoff(Duration.ofSeconds(2)))
-        }
-        return unpackedPath!!
+        throw UnsupportedOperationException("Download of this HttpDatasetPackage (downloadPath='$downloadPath') could not be executed. Create HttpDatasetPackage instance using the two-parameters constructor rather than the deprecated three-parameters one.")
     }
 
     override fun toString(): String {
-        return "HttpDatasetPackage(downloadPath='$downloadPath', unpackedPath=$unpackedPath, downloadTimeout=$downloadTimeout, datasetBucket=$datasetBucket)"
+        return "HttpDatasetPackage(downloadPath='$downloadPath', unpackedPath=$unpackedPath, downloadTimeout=$downloadTimeout, datasetBucket=UNSUPPORTED)"
     }
 }


### PR DESCRIPTION
The https://s3.eu-central-1.amazonaws.com/jira-soke-tests-eu/ S3 bucket - which must not be used anymore - was only referenced when com.atlassian.performance.tools.infrastructure.api.dataset.HttpDatasetPackage deprecated three-parameter secondary constructor was used - resulting in ObsoleteHttpDatasetPackage instance created. But the download() operation for such-way constructed HttpDatasetPackage would fail anyways due to missing file in the deprecated jira-soke-tests-eu bucket. Therefore, I'm replacing the download() method at ObsoleteHttpDatasetPackage with throw UnsupportedOperationException implementation.