### PR TITLE
JPERF-838: Add Splunkforwarder.jsonifyLog4j method for Log4j1 and Log4j2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 build
 .idea
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.19.3...master
 
+### Added
+- Added `jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String, log4j2ConfigPath: String)` to `SplunkForwarder` to enable jsonifying log4j2 configurations. [JPERF-838]
+
 ## [4.19.3] - 2022-06-23
 [4.19.3]: https://github.com/atlassian/infrastructure/compare/release-4.19.2...release-4.19.3
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ configurations.all {
                 "org.jetbrains:annotations" -> useVersion("15.0")
                 "com.google.code.findbugs:jsr305" -> useVersion("3.0.2")
                 "org.apache.commons:commons-compress" -> useVersion("1.9")
+                "net.bytebuddy:byte-buddy" -> useVersion("1.12.14")
+                "org.seleniumhq.selenium:selenium-api" -> useVersion("3.11.0")
+                "org.seleniumhq.selenium:selenium-support" -> useVersion("3.11.0")
+                "org.seleniumhq.selenium:selenium-chrome-driver" -> useVersion("3.11.0")
             }
             when (requested.group) {
                 "org.jetbrains.kotlin" -> useVersion(kotlinVersion)
@@ -63,6 +67,7 @@ dependencies {
 
     webdriver().forEach { testCompile(it) }
     testCompile("junit:junit:4.12")
+    testCompile("org.mockito:mockito-core:[3.0.0, 4.8.0]")
     testCompile("com.atlassian.performance.tools:jira-software-actions:[1.0.0,2.0.0)")
     testCompile("org.hamcrest:hamcrest-library:1.3")
     testCompile("org.assertj:assertj-core:3.11.1")
@@ -72,6 +77,7 @@ dependencies {
 }
 
 fun webdriver(): List<String> = listOf(
+    "selenium-api",
     "selenium-support",
     "selenium-chrome-driver"
 ).map { module ->

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -1,13 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -24,7 +26,7 @@ commons-codec:commons-codec:1.10
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9
 org.apache.commons:commons-csv:1.3
@@ -45,8 +47,6 @@ org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,24 +1,30 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
+com.google.code.gson:gson:2.8.2
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:23.6-jre
 com.google.j2objc:j2objc-annotations:1.1
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
+com.squareup.okhttp3:okhttp:3.9.1
+com.squareup.okio:okio:1.13.0
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 javax.inject:javax.inject:1
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
+org.apache.commons:commons-exec:1.3
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
@@ -63,6 +69,8 @@ org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2
 org.seleniumhq.selenium:selenium-api:3.11.0
+org.seleniumhq.selenium:selenium-remote-driver:3.11.0
+org.seleniumhq.selenium:selenium-support:3.11.0
 org.slf4j:slf4j-api:1.8.0-alpha2
 org.sonatype.plexus:plexus-cipher:1.4
 org.sonatype.plexus:plexus-sec-dispatcher:1.4

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -1,13 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -25,7 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9
 org.apache.commons:commons-csv:1.3
@@ -72,8 +74,6 @@ org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:3.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -1,13 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -25,7 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9
 org.apache.commons:commons-csv:1.3
@@ -72,8 +74,6 @@ org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:3.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,13 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -25,7 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9
 org.apache.commons:commons-csv:1.3
@@ -72,8 +74,6 @@ org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:3.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -22,7 +23,8 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.9
@@ -43,10 +45,10 @@ org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
+org.mockito:mockito-core:4.8.0
+org.objenesis:objenesis:3.2
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -22,7 +23,8 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.9
@@ -43,10 +45,10 @@ org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
+org.mockito:mockito-core:4.8.0
+org.objenesis:objenesis:3.2
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,14 +1,15 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -29,7 +30,8 @@ javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -81,6 +83,7 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2
+org.mockito:mockito-core:4.8.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -1,14 +1,16 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -32,7 +34,8 @@ javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -84,11 +87,11 @@ org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:3.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2
+org.mockito:mockito-core:4.8.0
+org.objenesis:objenesis:3.2
 org.rauschig:jarchivelib:0.7.1
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -22,7 +23,8 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.9
@@ -43,10 +45,10 @@ org.hamcrest:hamcrest-library:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
+org.mockito:mockito-core:4.8.0
+org.objenesis:objenesis:3.2
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,14 +1,16 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.0
+com.atlassian.data:random-data:1.4.3
+com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.9.0
-com.atlassian.performance.tools:jira-software-actions:1.3.2
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.17.2
+com.atlassian.performance.tools:jira-software-actions:1.3.5
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.2.0
-com.atlassian.performance.tools:ssh:2.3.0
-com.atlassian.performance.tools:virtual-users:3.10.0
+com.atlassian.performance.tools:ssh:2.4.3
+com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.2
@@ -32,7 +34,8 @@ javax.annotation:javax.annotation-api:1.3.2
 javax.inject:javax.inject:1
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
-net.bytebuddy:byte-buddy:1.7.9
+net.bytebuddy:byte-buddy-agent:1.12.14
+net.bytebuddy:byte-buddy:1.12.14
 net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -84,11 +87,11 @@ org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:3.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.jsoup:jsoup:1.10.2
+org.mockito:mockito-core:4.8.0
+org.objenesis:objenesis:3.2
 org.rauschig:jarchivelib:0.7.1
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/Sed.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/Sed.kt
@@ -13,4 +13,28 @@ class Sed {
         val escapedOutput = output.replace("/", "\\/")
         connection.execute("sed -i -r 's/$escapedExpression/$escapedOutput/g' $file")
     }
+
+    fun safeReplace(
+        connection: SshConnection,
+        expression: String,
+        output: String,
+        file: String
+    ): SshConnection.SshResult {
+        val escapedExpression = expression.replace("/", "\\/")
+        val escapedOutput = output.replace("/", "\\/")
+        return connection.safeExecute("sed -i -r 's/$escapedExpression/$escapedOutput/g' $file")
+    }
+
+    fun safeReplaceXmlTag(
+        connection: SshConnection,
+        sourceTagName: String,
+        replacementString: String,
+        file: String
+    ): SshConnection.SshResult {
+        val escapedSource= sourceTagName.replace("/", "\\/")
+        val escapedReplacement= replacementString.replace("/", "\\/")
+        return connection.safeExecute("sed -i '/\\/$escapedSource/a\\\n" +
+            "            $escapedReplacement\n" +
+            "/$escapedSource/, /\\/$escapedSource/d' $file")
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/DisabledSplunkForwarder.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/DisabledSplunkForwarder.kt
@@ -12,6 +12,10 @@ class DisabledSplunkForwarder : SplunkForwarder {
         return
     }
 
+    override fun jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String, log4j2ConfigPath: String) {
+        return
+    }
+
     override fun getRequiredPorts(): List<Int> {
         return emptyList()
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/Log4jJsonifier.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/Log4jJsonifier.kt
@@ -1,0 +1,48 @@
+package com.atlassian.performance.tools.infrastructure.api.splunk
+
+import com.atlassian.performance.tools.infrastructure.api.Sed
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+
+
+class Log4jJsonifier {
+
+    private val logger: Logger = LogManager.getLogger(Log4jJsonifier::class.java)
+
+    fun jsonifyLog4j1(sshConnection: SshConnection, log4jPropertiesPath: String) {
+        Sed().replace(
+            connection = sshConnection,
+            expression = "NewLineIndentingFilteringPatternLayout",
+            output = "layout.JsonLayout",
+            file = log4jPropertiesPath
+        )
+    }
+
+    fun jsonifyLog4j1AndLog4j2(sshConnection: SshConnection, log4jPropertiesPath: String, log4j2ConfigPath: String) {
+        val log4j1Result = Sed().safeReplace(
+            connection = sshConnection,
+            expression = "NewLineIndentingFilteringPatternLayout",
+            output = "layout.JsonLayout",
+            file = log4jPropertiesPath
+        )
+        if (!log4j1Result.isSuccessful()) {
+            logger.info("Attempt to jsonify $log4jPropertiesPath was unsuccessful.")
+        }
+        val log4j2Result = Sed().safeReplaceXmlTag(
+            connection = sshConnection,
+            sourceTagName = "PatternLayout",
+            replacementString = "<AtlassianJsonLayout  filteringApplied=\"false\"/>",
+            file = log4j2ConfigPath
+        )
+        if (!log4j1Result.isSuccessful()) {
+            logger.info("Attempt to jsonify $log4j2ConfigPath was unsuccessful.")
+        }
+        if (!log4j1Result.isSuccessful() && !log4j2Result.isSuccessful()) {
+            throw Exception("Failed to jsonify any log4j configuration.")
+        }
+        if (log4j1Result.isSuccessful() && log4j2Result.isSuccessful()) {
+            logger.info("Migrated both log4j1 and log4j2 config files, ensure that's correct.")
+        }
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/SplunkForwarder.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/SplunkForwarder.kt
@@ -5,5 +5,6 @@ import com.atlassian.performance.tools.ssh.api.SshConnection
 interface SplunkForwarder {
     fun run(sshConnection: SshConnection, name: String, logsPath: String)
     fun jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String)
+    fun jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String, log4j2ConfigPath: String)
     fun getRequiredPorts(): List<Int>
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/UniversalSplunkForwarder.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/UniversalSplunkForwarder.kt
@@ -1,7 +1,6 @@
 package com.atlassian.performance.tools.infrastructure.api.splunk
 
 import com.atlassian.performance.tools.infrastructure.DockerImage
-import com.atlassian.performance.tools.infrastructure.api.Sed
 import com.atlassian.performance.tools.ssh.api.SshConnection
 
 
@@ -27,18 +26,18 @@ class UniversalSplunkForwarder(
             "--volume $logsPath:/var/log/jiralogs/",
             "--volume /var/lib/docker/containers:/host/containers:ro",
             "--volume /var/log:/docker/log:ro",
-            "--volume /var/run/docker.sock:/var/run/docker.sock:ro")
+            "--volume /var/run/docker.sock:/var/run/docker.sock:ro"
+        )
 
         splunkForwarderImage.run(sshConnection, parameters.joinToString(" "))
     }
 
     override fun jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String) {
-        Sed().replace(
-            connection = sshConnection,
-            expression = "NewLineIndentingFilteringPatternLayout",
-            output = "layout.JsonLayout",
-            file = log4jPropertiesPath
-        )
+        Log4jJsonifier().jsonifyLog4j1(sshConnection, log4jPropertiesPath)
+    }
+
+    override fun jsonifyLog4j(sshConnection: SshConnection, log4jPropertiesPath: String, log4j2ConfigPath: String) {
+        Log4jJsonifier().jsonifyLog4j1AndLog4j2(sshConnection, log4jPropertiesPath, log4j2ConfigPath)
     }
 
     override fun getRequiredPorts(): List<Int> {

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/Log4jJsonifierTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/splunk/Log4jJsonifierTest.kt
@@ -1,0 +1,88 @@
+package com.atlassian.performance.tools.infrastructure.api.splunk
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.mockito.Mockito
+
+
+internal class Log4jJsonifierTest {
+    companion object {
+        private const val LOG4J1_PROPERTIES = "jira-log4j.properties"
+        private const val LOG4J2_CONFIG = "jira-log4j2.xml"
+
+        private const val LOG4J1_REPLACEMENT_CMD =
+            "sed -i -r 's/NewLineIndentingFilteringPatternLayout/layout.JsonLayout/g'"
+        private const val LOG4J2_REPLACEMENT_CMD = "sed -i '/\\/PatternLayout/a\\\n" +
+            "            <AtlassianJsonLayout  filteringApplied=\"false\"\\/>\n" +
+            "/PatternLayout/, /\\/PatternLayout/d'"
+    }
+
+    private var mockConnection: SshConnection = Mockito.mock(SshConnection::class.java)
+    private var unsuccessfulResult: SshConnection.SshResult = SshConnection.SshResult(-1, "", "")
+    private var successfulResult: SshConnection.SshResult = SshConnection.SshResult(0, "", "")
+
+    @Test
+    fun testJsonifyLog4j1Old() {
+        Log4jJsonifier().jsonifyLog4j1(mockConnection, LOG4J1_PROPERTIES)
+
+        Mockito.verify(mockConnection)
+            .execute("$LOG4J1_REPLACEMENT_CMD $LOG4J1_PROPERTIES")
+    }
+
+    @Test
+    fun testJsonifyLog4j1And2BothSucceed() {
+        Mockito.`when`(mockConnection.safeExecute(Mockito.anyString()))
+            .thenReturn(successfulResult)
+
+        Log4jJsonifier().jsonifyLog4j1AndLog4j2(mockConnection, LOG4J1_PROPERTIES, LOG4J2_CONFIG)
+
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J1_REPLACEMENT_CMD $LOG4J1_PROPERTIES")
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J2_REPLACEMENT_CMD $LOG4J2_CONFIG")
+    }
+
+    @Test
+    fun testJsonifyLog4j1And2Only1Succeeds() {
+        Mockito.`when`(mockConnection.safeExecute(Mockito.anyString()))
+            .thenReturn(successfulResult)
+            .thenReturn(unsuccessfulResult)
+
+        Log4jJsonifier().jsonifyLog4j1AndLog4j2(mockConnection, LOG4J1_PROPERTIES, LOG4J2_CONFIG)
+
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J1_REPLACEMENT_CMD $LOG4J1_PROPERTIES")
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J2_REPLACEMENT_CMD $LOG4J2_CONFIG")
+    }
+
+    @Test
+    fun testJsonifyLog4j1And2Only2Succeeds() {
+        Mockito.`when`(mockConnection.safeExecute(Mockito.anyString()))
+            .thenReturn(unsuccessfulResult)
+            .thenReturn(successfulResult)
+
+        Log4jJsonifier().jsonifyLog4j1AndLog4j2(mockConnection, LOG4J1_PROPERTIES, LOG4J2_CONFIG)
+
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J1_REPLACEMENT_CMD $LOG4J1_PROPERTIES")
+        Mockito.verify(mockConnection)
+            .safeExecute("$LOG4J2_REPLACEMENT_CMD $LOG4J2_CONFIG")
+    }
+
+    @Test
+    fun testJsonifyLog4j1And2BothFail() {
+        Mockito.`when`(mockConnection.safeExecute(Mockito.anyString()))
+            .thenReturn(unsuccessfulResult)
+
+        assertThatThrownBy {
+            Log4jJsonifier().jsonifyLog4j1AndLog4j2(
+                mockConnection,
+                LOG4J1_PROPERTIES,
+                LOG4J2_CONFIG
+            )
+        }
+            .isInstanceOf(Exception::class.java)
+    }
+}


### PR DESCRIPTION
Add a new backwards compatible method to SplunkForwarders which can edit both log4j1 and log4j2 config files - so that it can work both with Jira < 9.5 as well as >= 9.5