### PR TITLE
Harden the Oracle JDK test

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdk11IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdk11IT.kt
@@ -1,17 +1,11 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.junit.Test
 
 class AdoptOpenJdk11IT {
 
     @Test
     fun shouldSupportJstat() {
-        SshUbuntuContainer.Builder().build().start().use { ssh ->
-            ssh.toSsh().newConnection().use { connection ->
-                JstatSupport(AdoptOpenJDK11()).shouldSupportJstat(connection)
-            }
-        }
+        JstatSupport(AdoptOpenJDK11()).shouldSupportJstat()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdkIT.kt
@@ -1,17 +1,11 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.junit.Test
 
 class AdoptOpenJdkIT {
 
     @Test
     fun shouldSupportJstat() {
-        SshUbuntuContainer.Builder().build().start().use { ssh ->
-            ssh.toSsh().newConnection().use { connection ->
-                JstatSupport(AdoptOpenJDK()).shouldSupportJstat(connection)
-            }
-        }
+        JstatSupport(AdoptOpenJDK()).shouldSupportJstat()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
@@ -3,7 +3,7 @@ package com.atlassian.performance.tools.infrastructure.api.jvm
 import com.atlassian.performance.tools.jvmtasks.api.ExponentialBackoff
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import java.io.File
 import java.time.Duration
 
@@ -26,7 +26,6 @@ class JstatSupport(
     )
     private val jarName = "hello-world-after-1m-wait.jar"
     private val jar = "/com/atlassian/performance/tools/infrastructure/api/jvm/$jarName"
-    private val timestampLength = "2018-12-17T14:10:44+00:00 ".length
 
     fun shouldSupportJstat(connection: SshConnection) {
         connection.execute("apt-get install curl screen -y -qq", Duration.ofMinutes(2))
@@ -43,10 +42,9 @@ class JstatSupport(
         val jstatMonitoring = jdk.jstatMonitoring.start(connection, pid.toInt())
         waitForJstatToCollectSomeData()
         jstatMonitoring.stop(connection)
-        val jstatLog = connection.execute("cat ${jstatMonitoring.getResultPath()}").output
-        val jstatHeader = jstatLog.substring(timestampLength, jstatLog.indexOf('\n'))
+        val jstatLog = connection.execute("head -n 1 ${jstatMonitoring.getResultPath()}").output
 
-        Assertions.assertThat(jstatHeader).contains(this.expectedStats)
+        assertThat(jstatLog).contains(this.expectedStats)
     }
 
     private fun waitForJstatToCollectSomeData() {

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJdk11IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJdk11IT.kt
@@ -1,17 +1,11 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.junit.Test
 
 class OpenJdk11IT {
 
     @Test
     fun shouldSupportJstat() {
-        SshUbuntuContainer.Builder().build().start().use { ssh ->
-            ssh.toSsh().newConnection().use { connection ->
-                JstatSupport(OpenJDK11()).shouldSupportJstat(connection)
-            }
-        }
+        JstatSupport(OpenJDK11()).shouldSupportJstat()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OpenJdkIT.kt
@@ -1,17 +1,11 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.junit.Test
 
 class OpenJdkIT {
 
     @Test
     fun shouldSupportJstat() {
-        SshUbuntuContainer.Builder().build().start().use { ssh ->
-            ssh.toSsh().newConnection().use { connection ->
-                JstatSupport(OpenJDK()).shouldSupportJstat(connection)
-            }
-        }
+        JstatSupport(OpenJDK()).shouldSupportJstat()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
@@ -8,10 +8,11 @@ class OracleJdkIT {
 
     @Test
     fun shouldSupportJstatAndThreadDumps() {
-        SshUbuntuContainer.Builder().build().start().use { ssh ->
-            ssh.toSsh().newConnection().use { connection ->
-                val jdk = OracleJDK()
-                JstatSupport(jdk).shouldSupportJstat(connection)
+        val jdk = OracleJDK()
+        JstatSupport(jdk).shouldSupportJstat()
+        SshUbuntuContainer.Builder().build().start().use { ubuntu ->
+            val ssh = ubuntu.toSsh()
+            ssh.newConnection().use { connection ->
                 ThreadDumpTest().shouldGatherThreadDump(jdk, connection)
             }
         }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
@@ -1,7 +1,5 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
-import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.junit.Test
 
 class OracleJdkIT {
@@ -10,11 +8,6 @@ class OracleJdkIT {
     fun shouldSupportJstatAndThreadDumps() {
         val jdk = OracleJDK()
         JstatSupport(jdk).shouldSupportJstat()
-        SshUbuntuContainer.Builder().build().start().use { ubuntu ->
-            val ssh = ubuntu.toSsh()
-            ssh.newConnection().use { connection ->
-                ThreadDumpTest().shouldGatherThreadDump(jdk, connection)
-            }
-        }
+        ThreadDumpTest(jdk).shouldGatherThreadDump()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
@@ -5,9 +5,12 @@ import org.junit.Test
 class OracleJdkIT {
 
     @Test
-    fun shouldSupportJstatAndThreadDumps() {
-        val jdk = OracleJDK()
-        JstatSupport(jdk).shouldSupportJstat()
-        ThreadDumpTest(jdk).shouldGatherThreadDump()
+    fun shouldSupportJstat() {
+        JstatSupport(OracleJDK()).shouldSupportJstat()
+    }
+
+    @Test
+    fun shouldGatherThreadDump() {
+        ThreadDumpTest(OracleJDK()).shouldGatherThreadDump()
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
@@ -1,19 +1,32 @@
 package com.atlassian.performance.tools.infrastructure.api.jvm
 
+import com.atlassian.performance.tools.infrastructure.toSsh
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
 import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
+import com.atlassian.performance.tools.ssh.api.Ssh
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import org.assertj.core.api.Assertions
+import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
+import org.assertj.core.api.Assertions.assertThat
 import java.time.Duration
 
-class ThreadDumpTest {
-    fun shouldGatherThreadDump(jdk: JavaDevelopmentKit, connection: SshConnection) {
+class ThreadDumpTest(
+    private val jdk: JavaDevelopmentKit
+) {
+    fun shouldGatherThreadDump() {
+        SshUbuntuContainer.Builder().build().start().use { ubuntu ->
+            val ssh = ubuntu.toSsh()
+            ssh.newConnection().use { connection ->
+                shouldGatherThreadDump(ssh, connection)
+            }
+        }
+    }
+
+    private fun shouldGatherThreadDump(ssh: Ssh, connection: SshConnection) {
         jdk.install(connection)
         val destination = "thread-dumps"
         connection.execute("""echo "public class Test { public static void main(String[] args) { try { Thread.sleep(java.time.Duration.ofMinutes(1).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); } }}" > Test.java """.trimIndent())
         connection.execute("${jdk.use()}; javac Test.java")
-        val process = connection.startProcess("${jdk.use()}; java Test")
-        try {
+        ssh.runInBackground("${jdk.use()}; java Test").use {
             val pid = IdempotentAction("Get PID") {
                 getPid(connection, jdk)
             }.retry(maxAttempts = 2, backoff = StaticBackoff(Duration.ofSeconds(1)))
@@ -22,11 +35,7 @@ class ThreadDumpTest {
 
             val threadDumpFile = connection.execute("ls $destination").output
             val threadDump = connection.execute("cat $destination/$threadDumpFile").output
-            Assertions.assertThat(threadDump).contains("Full thread dump Java HotSpot")
-        } catch (e: Exception) {
-            throw Exception(e)
-        } finally {
-            connection.stopProcess(process)
+            assertThat(threadDump).contains("Full thread dump Java HotSpot")
         }
     }
 

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/ThreadDumpIT.kt
@@ -8,6 +8,7 @@ import java.time.Duration
 
 class ThreadDumpTest {
     fun shouldGatherThreadDump(jdk: JavaDevelopmentKit, connection: SshConnection) {
+        jdk.install(connection)
         val destination = "thread-dumps"
         connection.execute("""echo "public class Test { public static void main(String[] args) { try { Thread.sleep(java.time.Duration.ofMinutes(1).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); } }}" > Test.java """.trimIndent())
         connection.execute("${jdk.use()}; javac Test.java")


### PR DESCRIPTION
It [flaked](https://scans.gradle.com/s/4afgikeqjjoaa/tests/:testIntegration/com.atlassian.performance.tools.infrastructure.api.jvm.OracleJdkIT/shouldSupportJstatAndThreadDumps?page=eyJvdXRwdXQiOnsiMCI6Mn19&top-execution=1) on a recent [release attempt](https://github.com/atlassian/infrastructure/actions/runs/3419471790), so here's some hardening.