### PR TITLE
JPERF-969 Prefer IPv4 before starting download of http resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Bump `AsyncProfiler` to v2.9.
 - Retry starting the `AsyncProfiler`. Fix [JPERF-969] flakiness.
+- Prefer IPv4 in `HttpResource`. It fixes running tests on Github CI. Fix [JPERF-969].
 
 [JPERF-969]: https://ecosystem.atlassian.net/browse/JPERF-969
 
@@ -46,6 +47,8 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Update `curl` command used for downloading Oracle JDK. Unblocks [JPERF-917].
+
+[JPERF-917]: https://ecosystem.atlassian.net/browse/JPERF-917
 
 ## [4.22.1] - 2022-12-07
 [4.22.1]: https://github.com/atlassian/infrastructure/compare/release-4.21.0...release-4.22.1

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/HttpResource.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/HttpResource.kt
@@ -27,7 +27,7 @@ class HttpResource(
     ) {
         Ubuntu().install(ssh, listOf("lftp"), Duration.ofMinutes(2))
         ssh.execute(
-            """lftp -c 'set net:timeout 15; set net:max-retries 50; pget -n 32 -c "$uri" -o $destination'""",
+            """lftp -c 'set dns:order "inet inet6"; set net:timeout 15; set net:max-retries 50; pget -n 32 -c "$uri" -o $destination'""",
             timeout
         )
     }


### PR DESCRIPTION
It fixes running downloads on github actions where it previously failed with errors like:
`Error while executing lftp -c 'set net:timeout 15; set net:max-retries 50; pget -n 32 -c "https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-7.13.0.tar.gz" -o ./atlassian-jira-software-7.13.0.tar.gz'. Exit status code SshResult(exitStatus=1, output=, errorOutput=pget: /software/jira/downloads/atlassian-jira-software-7.13.0.tar.gz: Cannot assign requested address`