### PR TITLE
JPERF-996: Fix fresh dataset compatibility by adding MySQL arguments from Jira documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.22.4...master
 
+### Fixed
+- Fix fresh dataset compatibility by adding MySQL arguments from Jira documentation. Unblock [JPERF-996].
+
+[JPERF-996]: https://ecosystem.atlassian.net/browse/JPERF-996
+
 ## [4.22.4] - 2023-02-15
 [4.22.4]: https://github.com/atlassian/infrastructure/compare/release-4.22.3...release-4.22.4
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MySqlDatabase.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MySqlDatabase.kt
@@ -28,6 +28,23 @@ class MySqlDatabase(
     private val ubuntu = Ubuntu()
 
     /**
+     * Arguments based on [jira docs](https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html).
+     *
+     * We skip setting `--sql-mode` even though the docs says:
+     * "Ensure the sql_mode parameter does not specify NO_AUTO_VALUE_ON_ZERO".
+     * It's unclear what value should be set and the based on [mysql docs](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
+     * the defaults are good.
+     */
+    private val jiraDocsBasedArgs = listOf(
+        "--default-storage-engine=INNODB",
+        "--character-set-server=utf8mb4",
+        "--innodb-default-row-format=DYNAMIC",
+        "--innodb-large-prefix=ON",
+        "--innodb-file-format=Barracuda",
+        "--innodb-log-file-size=2G"
+    ).joinToString(" ")
+
+    /**
      * Uses MySQL defaults.
      */
     constructor(
@@ -42,7 +59,7 @@ class MySqlDatabase(
         image.run(
             ssh = ssh,
             parameters = "-p 3306:3306 -v `realpath $mysqlDataLocation`:/var/lib/mysql",
-            arguments = "--skip-grant-tables --max_connections=$maxConnections"
+            arguments = "$jiraDocsBasedArgs --skip-grant-tables --max_connections=$maxConnections"
         )
         return mysqlDataLocation
     }


### PR DESCRIPTION
Some of those args are needed when a new MySQL 5.7 is generated using https://hub.docker.com/_/mysql and https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html

Problem faced without those arguments was Jira starting with error page claiming:
> The database setup is not supporting utf8mb4
> See out documentation for more information on setting up MySQL 5.7
> [Learn more](https://confluence.atlassian.com/jirakb/change-mysql-connection-url-for-jira-server-874744240.html)

We're adding all of the arguments from docs, because there is no reason not to.