### PR TITLE
JPERF-996: Allow minimal MySQL setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.23.0...master
 
+### Added
+- Allow minimal Jira setup using new `MinimalMysqlDatabase` and `MinimalMysqlJiraHome` APIs.
+- Copy `MySqlDatabase` as `MysqlDatabase` to maintain consistent naming.
+- Introduce `MysqlDatabase.Builder`.
+
+### Deprecated
+- `MySqlDatabase` in favour of `MysqlDatabase`.
+
 ## [4.23.0] - 2023-02-27
 [4.23.0]: https://github.com/atlassian/infrastructure/compare/release-4.22.5...release-4.23.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MinimalMySqlDatabase.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MinimalMySqlDatabase.kt
@@ -1,0 +1,52 @@
+package com.atlassian.performance.tools.infrastructure.api.database
+
+import com.atlassian.performance.tools.infrastructure.database.Mysql
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.net.URI
+
+class MinimalMysqlDatabase private constructor(
+    private val jiraDbUserPassword: String,
+    private val maxConnections: Int
+) : Database {
+    override fun setup(ssh: SshConnection): String {
+        val mysqlDataLocation = "mySqlData"
+        ssh.execute("mkdir -p $mysqlDataLocation")
+        Mysql
+            .container(
+                dataDir = mysqlDataLocation,
+                extraParameters = arrayOf("-e MYSQL_ALLOW_EMPTY_PASSWORD=yes"),
+                extraArguments = arrayOf("--max_connections=$maxConnections")
+            )
+            .run(ssh)
+        return mysqlDataLocation
+    }
+
+    override fun start(jira: URI, ssh: SshConnection) {
+        val client = Mysql.installClient(ssh)
+        Mysql.awaitDatabase(ssh)
+
+        // Based on [jira docs](https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html)
+        client.runSql(ssh, "CREATE USER 'jiradbuser'@'%' IDENTIFIED BY '$jiraDbUserPassword';")
+        client.runSql(ssh, "CREATE DATABASE jiradb CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;")
+        client.runSql(ssh, """
+            GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,REFERENCES,ALTER,INDEX on jiradb.* TO 'jiradbuser'@'%' IDENTIFIED BY '$jiraDbUserPassword';
+            flush privileges;
+        """.trimIndent())
+    }
+
+    class Builder {
+        private var jiraDbUserPassword: String = "password"
+
+        private var maxConnections: Int = 151
+
+        fun jiraDbUserPassword(jiraDbUserPassword: String) = apply { this.jiraDbUserPassword = jiraDbUserPassword }
+
+        @Suppress("unused")
+        fun maxConnections(maxConnections: Int) = apply { this.maxConnections = maxConnections }
+
+        fun build() = MinimalMysqlDatabase(
+            jiraDbUserPassword,
+            maxConnections
+        )
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MySqlDatabase.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MySqlDatabase.kt
@@ -1,45 +1,68 @@
 package com.atlassian.performance.tools.infrastructure.api.database
 
-import com.atlassian.performance.tools.infrastructure.api.docker.DockerContainer
 import com.atlassian.performance.tools.infrastructure.api.dataset.DatasetPackage
-import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
+import com.atlassian.performance.tools.infrastructure.database.Mysql
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import java.net.URI
-import java.time.Duration
-import java.time.Instant
+
+/**
+ * Compatible with Ubuntu 16.04, 18.04, 20.04 and 22.04.
+ * @param maxConnections MySQL `max_connections` parameter.
+ */
+class MysqlDatabase private constructor(
+    private val source: DatasetPackage,
+    private val maxConnections: Int
+) : Database {
+    override fun setup(ssh: SshConnection): String {
+        val mysqlDataLocation = source.download(ssh)
+        Mysql
+            .container(
+                dataDir = mysqlDataLocation,
+                extraParameters = emptyArray(),
+                extraArguments = arrayOf(
+                    "--skip-grant-tables", // Recovery mode, as some datasets give no permissions to their root DB user
+                    "--max_connections=$maxConnections"
+                )
+            )
+            .run(ssh)
+        return mysqlDataLocation
+    }
+
+    override fun start(jira: URI, ssh: SshConnection) {
+        val client = Mysql.installClient(ssh)
+        Mysql.awaitDatabase(ssh)
+
+        client.runSql(ssh, "UPDATE jiradb.propertystring SET propertyvalue = '$jira' WHERE id IN (select id from jiradb.propertyentry where property_key like '%baseurl%');")
+    }
+
+    class Builder(
+        private var source: DatasetPackage
+    ) {
+        private var maxConnections: Int = 151
+
+        fun source(source: DatasetPackage) = apply { this.source = source }
+
+        fun maxConnections(maxConnections: Int) = apply { this.maxConnections = maxConnections }
+
+        fun build() = MysqlDatabase(
+            source,
+            maxConnections
+        )
+    }
+}
 
 /**
  * Since 4.21.0, it's compatible with Ubuntu 16.04, 18.04, 20.04 and 22.04.
  * @param maxConnections MySQL `max_connections` parameter.
  */
+@Deprecated("Use `MysqlDatabase` for naming consistency")
 class MySqlDatabase(
     private val source: DatasetPackage,
     private val maxConnections: Int
-) : Database {
-
-    private val logger: Logger = LogManager.getLogger(this::class.java)
-
-    private val ubuntu = Ubuntu()
-
-    /**
-     * Arguments based on [jira docs](https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html).
-     *
-     * We skip setting `--sql-mode` even though the docs says:
-     * "Ensure the sql_mode parameter does not specify NO_AUTO_VALUE_ON_ZERO".
-     * It's unclear what value should be set and the based on [mysql docs](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
-     * the defaults are good.
-     */
-    private val jiraDocsBasedArgs = arrayOf(
-        "--default-storage-engine=INNODB",
-        "--character-set-server=utf8mb4",
-        "--innodb-default-row-format=DYNAMIC",
-        "--innodb-large-prefix=ON",
-        "--innodb-file-format=Barracuda",
-        "--innodb-log-file-size=2G"
-    )
-
+) : Database by MysqlDatabase.Builder(source)
+    .maxConnections(maxConnections)
+    .build()
+{
     /**
      * Uses MySQL defaults.
      */
@@ -49,40 +72,4 @@ class MySqlDatabase(
         source = source,
         maxConnections = 151
     )
-
-    override fun setup(ssh: SshConnection): String {
-        val mysqlDataLocation = source.download(ssh)
-        DockerContainer.Builder()
-            .imageName("mysql:5.7.32")
-            .pullTimeout(Duration.ofMinutes(5))
-            .parameters(
-                "-p 3306:3306",
-                "-v `realpath $mysqlDataLocation`:/var/lib/mysql"
-            )
-            .arguments(
-                *jiraDocsBasedArgs,
-                "--skip-grant-tables",
-                "--max_connections=$maxConnections"
-            )
-            .build()
-            .run(ssh)
-        return mysqlDataLocation
-    }
-
-    override fun start(jira: URI, ssh: SshConnection) {
-        waitForMysql(ssh)
-        ssh.execute("""mysql -h 127.0.0.1  -u root -e "UPDATE jiradb.propertystring SET propertyvalue = '$jira' WHERE id IN (select id from jiradb.propertyentry where property_key like '%baseurl%');" """)
-    }
-
-    private fun waitForMysql(ssh: SshConnection) {
-        ubuntu.install(ssh, listOf("mysql-client"))
-        val mysqlStart = Instant.now()
-        while (!ssh.safeExecute("mysql -h 127.0.0.1 -u root -e 'select 1;'").isSuccessful()) {
-            if (Instant.now() > mysqlStart + Duration.ofMinutes(15)) {
-                throw RuntimeException("MySql didn't start in time")
-            }
-            logger.debug("Waiting for MySQL...")
-            Thread.sleep(Duration.ofSeconds(10).toMillis())
-        }
-    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/MinimalMySqlJiraHome.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/MinimalMySqlJiraHome.kt
@@ -1,0 +1,15 @@
+package com.atlassian.performance.tools.infrastructure.api.jira
+
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.nio.file.Files
+
+class MinimalMysqlJiraHome : JiraHomeSource {
+    override fun download(ssh: SshConnection): String {
+        val temporaryDirectory = Files.createTempDirectory("jpt-jirahome").toFile()
+        this::class.java.classLoader.getResourceAsStream("mysql-dbconfig.xml")!!.use { inputStream ->
+            temporaryDirectory.resolve("dbconfig.xml").outputStream().use { inputStream.copyTo(it) }
+        }
+        ssh.upload(temporaryDirectory, "jirahome")
+        return "jirahome"
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/MySql.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/database/MySql.kt
@@ -1,0 +1,65 @@
+package com.atlassian.performance.tools.infrastructure.database
+
+import com.atlassian.performance.tools.infrastructure.api.docker.DockerContainer
+import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.time.Duration
+import java.time.Instant
+
+internal object Mysql {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+    private val ubuntu = Ubuntu()
+
+    /**
+     * Arguments based on [jira docs](https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html).
+     *
+     * We skip setting `--sql-mode` even though the docs says:
+     * "Ensure the sql_mode parameter does not specify NO_AUTO_VALUE_ON_ZERO".
+     * It's unclear what value should be set and the based on [mysql docs](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
+     * the defaults are good.
+     */
+    private val jiraDocsBasedArgs = arrayOf(
+        "--default-storage-engine=INNODB",
+        "--character-set-server=utf8mb4",
+        "--innodb-default-row-format=DYNAMIC",
+        "--innodb-large-prefix=ON",
+        "--innodb-file-format=Barracuda",
+        "--innodb-log-file-size=2G"
+    )
+
+    fun installClient(ssh: SshConnection): SshSqlClient {
+        ubuntu.install(ssh, listOf("mysql-client"))
+        return SshMysqlClient()
+    }
+
+    fun container(
+        dataDir: String,
+        extraParameters: Array<String>,
+        extraArguments: Array<String>
+    ) = DockerContainer.Builder()
+        .imageName("mysql:5.7.32")
+        .pullTimeout(Duration.ofMinutes(5))
+        .parameters(
+            "-p 3306:3306",
+            "-v `realpath $dataDir`:/var/lib/mysql",
+            *extraParameters
+        )
+        .arguments(
+            *jiraDocsBasedArgs,
+            *extraArguments
+        )
+        .build()
+
+    fun awaitDatabase(ssh: SshConnection) {
+        val mysqlStart = Instant.now()
+        while (!ssh.safeExecute("mysql -h 127.0.0.1 -u root -e 'select 1;'").isSuccessful()) {
+            if (Instant.now() > mysqlStart + Duration.ofMinutes(15)) {
+                throw RuntimeException("MySQL didn't start in time")
+            }
+            logger.debug("Waiting for MySQL...")
+            Thread.sleep(Duration.ofSeconds(10).toMillis())
+        }
+    }
+}

--- a/src/main/resources/mysql-dbconfig.xml
+++ b/src/main/resources/mysql-dbconfig.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Sample copied from https://confluence.atlassian.com/adminjiraserver/connecting-jira-applications-to-mysql-5-7-966063305.html -->
+<jira-database-config>
+    <name>defaultDS</name>
+    <delegator-name>default</delegator-name>
+    <database-type>mysql57</database-type>
+    <jdbc-datasource>
+        <url>jdbc:mysql://dbserver:3306/jiradb?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=default_storage_engine=InnoDB</url>
+        <driver-class>com.mysql.jdbc.Driver</driver-class>
+        <username>jiradbuser</username>
+        <password>password</password>
+        <pool-min-size>20</pool-min-size>
+        <pool-max-size>20</pool-max-size>
+        <pool-max-wait>30000</pool-max-wait>
+        <pool-max-idle>20</pool-max-idle>
+        <pool-remove-abandoned>true</pool-remove-abandoned>
+        <pool-remove-abandoned-timeout>300</pool-remove-abandoned-timeout>
+
+        <validation-query>select 1</validation-query>
+        <min-evictable-idle-time-millis>60000</min-evictable-idle-time-millis>
+        <time-between-eviction-runs-millis>300000</time-between-eviction-runs-millis>
+
+        <pool-test-while-idle>true</pool-test-while-idle>
+        <pool-test-on-borrow>false</pool-test-on-borrow>
+        <validation-query-timeout>3</validation-query-timeout>
+    </jdbc-datasource>
+</jira-database-config>

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MinimalMySqlDatabaseIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/database/MinimalMySqlDatabaseIT.kt
@@ -1,0 +1,31 @@
+package com.atlassian.performance.tools.infrastructure.api.database
+
+import com.atlassian.performance.tools.infrastructure.toSsh
+import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
+import org.junit.Test
+import java.net.URI
+import java.util.function.Consumer
+
+class MinimalMysqlDatabaseIT {
+    @Test
+    fun `can be used by jiradbuser`() {
+        val assumedUser = "jiradbuser"
+        val password = "static-integration-test-password"
+        val mysql = MinimalMysqlDatabase.Builder()
+            .jiraDbUserPassword(password)
+            .build()
+
+        SshUbuntuContainer.Builder()
+            .customization(Consumer { it.setPrivilegedMode(true) })
+            .build()
+            .start()
+            .use { ubuntu ->
+                ubuntu.toSsh().newConnection().use { ssh ->
+                    mysql.setup(ssh)
+                    mysql.start(URI("https://dummy-jira.net"), ssh)
+
+                    ssh.execute("mysql -h 127.0.0.1 -u $assumedUser -p$password -e 'USE jiradb; SHOW TABLES;'")
+                }
+            }
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/MinimalMySqlJiraHomeTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jira/MinimalMySqlJiraHomeTest.kt
@@ -1,0 +1,30 @@
+package com.atlassian.performance.tools.infrastructure.api.jira
+
+import com.atlassian.performance.tools.infrastructure.mock.UnimplementedSshConnection
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.File
+
+class MinimalMysqlJiraHomeTest {
+
+    @Test
+    fun `uploads jirahome only with dbconfig xml`() {
+        val ssh = SshMock()
+
+        MinimalMysqlJiraHome().download(ssh)
+
+        val jirahome = ssh.lastUpload!!
+        val content = jirahome.listFiles()!!
+        assertThat(content.map { it.name }, equalTo(listOf("dbconfig.xml")))
+    }
+
+    private class SshMock : SshConnection by UnimplementedSshConnection() {
+        var lastUpload: File? = null
+
+        override fun upload(localSource: File, remoteDestination: String) {
+            this.lastUpload = localSource
+        }
+    }
+}


### PR DESCRIPTION
New MySQL database can't be initialized with `--skip-grant-tables` and we need to add this flag for existing datasets
to recover from lack of GRANTs in most of those.

We don't need to update Jira's baseurl in new database, as it's set during Jira setup in web GUI.

New `MinimalMysqlDatabaseIT` adds around 2 min test time on my machine.

Mutating the code by removing `GRANT` from `MinimalMysqlDatabase` breaks the test.

New `MinimalMysqlJiraHomeTest` adds around 30 ms test time on my machine.

Currently `aws-infrastructure` module is not compatile with new API. An ability to skip Jira upgrade waiting is needed.
Draft can be found under https://github.com/atlassian/aws-infrastructure/pull/154

We are intentionally not cleaning up created temp dirs, as team believes it's unnecessary.

We are deprecating `MySqlDatabase` to avoid inconsistent naming propagation in the code. With this opportunity it's good to intoduce
`MysqlDatabase.Builder`, so that we can hide unnecessary constructors.