### PR TITLE
JPERF-1081: Extend `AsyncProfiler` `stop` timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Wait until Docker is started before pulling images. Fix [JPERF-1104].
+- Extend `AsyncProfiler` `stop` timeout. Fix [JPERF-1081].
 
 [JPERF-1104]: https://ecosystem.atlassian.net/browse/JPERF-1104
+[JPERF-1081]: https://ecosystem.atlassian.net/browse/JPERF-1081
 
 ## [4.24.1] - 2023-05-10
 [4.24.1]: https://github.com/atlassian/infrastructure/compare/release-4.24.0...release-4.24.1

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/AsyncProfiler.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/AsyncProfiler.kt
@@ -4,6 +4,7 @@ import com.atlassian.performance.tools.infrastructure.api.process.RemoteMonitori
 import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
 import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
 import com.atlassian.performance.tools.ssh.api.SshConnection
+import java.time.Duration
 import java.time.Duration.ofSeconds
 
 /**
@@ -39,7 +40,7 @@ class AsyncProfiler : Profiler {
         private val flameGraphFile = "flamegraph.svg"
 
         override fun stop(ssh: SshConnection) {
-            ssh.execute("$script stop $pid -o flamegraph > $flameGraphFile")
+            ssh.execute("$script stop $pid -o flamegraph > $flameGraphFile", timeout = ofSeconds(50))
         }
 
         override fun getResultPath(): String {


### PR DESCRIPTION
Fix errors like:
```
Caused by: java.lang.Exception: SSH command exceeded timeout PT30S by PT2.861S
	at com.atlassian.performance.tools.ssh.WaitingCommand.waitForCompletion(WaitingCommand.kt:43) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.ssh.WaitingCommand.waitForResult(WaitingCommand.kt:21) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.ssh.SshjConnection.safeExecute(SshjConnection.kt:63) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.ssh.SshjConnection.safeExecute(SshjConnection.kt:52) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.ssh.SshjConnection.execute(SshjConnection.kt:33) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.ssh.api.SshConnection.execute(SshConnection.kt:27) ~[ssh-2.4.3.jar:?]
	at com.atlassian.performance.tools.infrastructure.api.profiler.AsyncProfiler$ProfilerProcess.stop(AsyncProfiler.kt:42) ~[infrastructure-4.24.0.jar:?]
	at com.atlassian.performance.tools.awsinfrastructure.api.jira.StartedNode.gatherResults(StartedNode.kt:23) ~[aws-infrastructure-2.29.0.jar:?]
	at com.atlassian.performance.tools.awsinfrastructure.api.jira.Jira$gatherResults$1$1.invoke(Jira.kt:34) ~[aws-infrastructure-2.29.0.jar:?]
	at com.atlassian.performance.tools.awsinfrastructure.api.jira.Jira$gatherResults$1$1.invoke(Jira.kt:14) ~[aws-infrastructure-2.29.0.jar:?]
	... 6 more
```
I guess that longer profiling session can take more time to dump the data into a flamegraph.