### PR TITLE
Issue/jperf 1090 export java home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 - Stop forcing JSON Jira logs. Using `JiraNodeConfig.Builder.splunkForwarder` should no longer mess with Jira logs,
   when `DisabledSplunkForwarder` (the default) is used.
 - Respect the `splunkForwarder` delegate in `Log4j2SplunkForwarder`, without assuming its implementation.
+- Export `JAVA_HOME` during `OracleJDK` installation.
+- Export `JAVA_HOME` to `.profile` instead of `.bashrc`. Fix [JPERF-1090].
+
+[JPERF-1090]: https://ecosystem.atlassian.net/browse/JPERF-1090
 
 ## [4.24.0] - 2023-03-01
 [4.24.0]: https://github.com/atlassian/infrastructure/compare/release-4.23.0...release-4.24.0

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK.kt
@@ -10,8 +10,9 @@ class AdoptOpenJDK : VersionedJavaDevelopmentKit {
     private val jdkVersion = "8u172-b11"
     private val jdkArchive = "OpenJDK8_x64_Linux_jdk$jdkVersion.tar.gz"
     private val jdkUrl = URI("https://github.com/AdoptOpenJDK/openjdk8-releases/releases/download/jdk$jdkVersion/$jdkArchive")
-    private val jreBin = "~/jdk$jdkVersion/jre/bin/"
-    private val jdkBin = "~/jdk$jdkVersion/bin/"
+    private val path = "~/jdk$jdkVersion"
+    private val jreBin = "$path/jre/bin/"
+    private val jdkBin = "$path/bin/"
     override val jstatMonitoring: Jstat = Jstat(jdkBin)
 
     override fun getMajorVersion() = 8
@@ -19,11 +20,12 @@ class AdoptOpenJDK : VersionedJavaDevelopmentKit {
     override fun install(connection: SshConnection) {
         download(connection)
         connection.execute("tar -xzf $jdkArchive")
-        connection.execute("echo '${use()}' >> ~/.bashrc")
+        connection.execute("echo '${use()}' >> ~/.profile")
     }
 
-    override fun use(): String =
-        "export PATH=${'$'}PATH:$jreBin:$jdkBin && export JAVA_HOME=~/jdk$jdkVersion"
+    override fun use(): String {
+        return "export PATH=${'$'}PATH:$jreBin:$jdkBin; export JAVA_HOME=$path"
+    }
 
     override fun command(options: String) = "${jdkBin}java $options"
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK11.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJDK11.kt
@@ -9,6 +9,7 @@ import java.time.Duration
 class AdoptOpenJDK11 : VersionedJavaDevelopmentKit {
     private val jdkVersion = "-11.0.1+13"
     private val jdkArchive = "OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
+
     /**
      * Download URL
      * https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1+13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz
@@ -16,8 +17,9 @@ class AdoptOpenJDK11 : VersionedJavaDevelopmentKit {
      * https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1+13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz
      */
     private val jdkUrl = URI("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk$jdkVersion/$jdkArchive")
-    private val jreBin = "~/jdk$jdkVersion/jre/bin/"
-    private val jdkBin = "~/jdk$jdkVersion/bin/"
+    private val path = "~/jdk$jdkVersion"
+    private val jreBin = "$path/jre/bin/"
+    private val jdkBin = "$path/bin/"
     override val jstatMonitoring: Jstat = Jstat(jdkBin)
 
     override fun getMajorVersion() = 11
@@ -25,11 +27,11 @@ class AdoptOpenJDK11 : VersionedJavaDevelopmentKit {
     override fun install(connection: SshConnection) {
         download(connection)
         connection.execute("tar -xzf $jdkArchive")
-        connection.execute("echo '${use()}' >> ~/.bashrc")
+        connection.execute("echo '${use()}' >> ~/.profile")
     }
 
     override fun use(): String =
-        "export PATH=${'$'}PATH:$jreBin:$jdkBin && export JAVA_HOME=~/jdk$jdkVersion"
+        "export PATH=${'$'}PATH:$jreBin:$jdkBin && export JAVA_HOME=$path"
 
     override fun command(options: String) = "${jdkBin}java $options"
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJDK.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJDK.kt
@@ -6,13 +6,15 @@ import org.apache.logging.log4j.Logger
 import java.net.URI
 import java.time.Duration
 
+
 class OracleJDK : VersionedJavaDevelopmentKit {
     private val logger: Logger = LogManager.getLogger(this::class.java)
     private val jdkUpdate = 131
     private val jdkArchive = "jdk-8u$jdkUpdate-linux-x64.tar.gz"
     private val jdkUrl = URI.create("https://download.oracle.com/otn-pub/java/jdk/8u$jdkUpdate-b11/d54c1d3a095b4ff2b6607d096fa80163/$jdkArchive")
-    private val jdkBin = "~/jdk1.8.0_$jdkUpdate/jre/bin/"
-    private val bin = "~/jdk1.8.0_$jdkUpdate/bin/"
+    private val path = "~/jdk1.8.0_$jdkUpdate"
+    private val jreBin = "$path/jre/bin/"
+    private val bin = "$path/bin/"
     override val jstatMonitoring = Jstat(bin)
 
     @Deprecated(
@@ -26,12 +28,12 @@ class OracleJDK : VersionedJavaDevelopmentKit {
     override fun install(connection: SshConnection) {
         download(connection)
         connection.execute("tar -xzf $jdkArchive")
-        connection.execute("echo '${use()}' >> ~/.bashrc")
+        connection.execute("echo '${use()}' >> ~/.profile")
     }
 
-    override fun use(): String = "export PATH=$jdkBin:$bin:${'$'}PATH"
+    override fun use(): String = "export PATH=$jreBin:$bin:${'$'}PATH; export JAVA_HOME=$path"
 
-    override fun command(options: String) = "${jdkBin}java $options"
+    override fun command(options: String) = "${jreBin}java $options"
 
     private fun download(connection: SshConnection) {
         val attempts = 0..3

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdk11IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdk11IT.kt
@@ -8,4 +8,9 @@ class AdoptOpenJdk11IT {
     fun shouldSupportJstat() {
         JstatSupport(AdoptOpenJDK11()).shouldSupportJstat()
     }
+
+    @Test
+    fun shouldHaveJavaHomeSet() {
+        JdkSupport(AdoptOpenJDK11()).shouldHaveJavaHomeSet("/jdk-11.0.1+13")
+    }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/AdoptOpenJdkIT.kt
@@ -8,4 +8,8 @@ class AdoptOpenJdkIT {
     fun shouldSupportJstat() {
         JstatSupport(AdoptOpenJDK()).shouldSupportJstat()
     }
+    @Test
+    fun shouldHaveJavaHomeSet() {
+        JdkSupport(AdoptOpenJDK()).shouldHaveJavaHomeSet("/jdk8u172-b11")
+    }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JdkSupport.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JdkSupport.kt
@@ -2,7 +2,7 @@ package com.atlassian.performance.tools.infrastructure.api.jvm
 
 import com.atlassian.performance.tools.infrastructure.toSsh
 import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 
 class JdkSupport(
     private val jdk: VersionedJavaDevelopmentKit
@@ -14,7 +14,7 @@ class JdkSupport(
                 jdk.install(connection)
                 val javaHomeOutput = connection.execute("source ~/.profile; echo \$JAVA_HOME").output
 
-                Assertions.assertThat(javaHomeOutput).contains(expectedJavaPath)
+                assertThat(javaHomeOutput).contains(expectedJavaPath)
             }
         }
     }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JdkSupport.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JdkSupport.kt
@@ -1,0 +1,21 @@
+package com.atlassian.performance.tools.infrastructure.api.jvm
+
+import com.atlassian.performance.tools.infrastructure.toSsh
+import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
+import org.assertj.core.api.Assertions
+
+class JdkSupport(
+    private val jdk: VersionedJavaDevelopmentKit
+) {
+    fun shouldHaveJavaHomeSet(expectedJavaPath: String) {
+        SshUbuntuContainer.Builder().build().start().use { ubuntu ->
+            val ssh = ubuntu.toSsh()
+            ssh.newConnection().use { connection ->
+                jdk.install(connection)
+                val javaHomeOutput = connection.execute("source ~/.profile; echo \$JAVA_HOME").output
+
+                Assertions.assertThat(javaHomeOutput).contains(expectedJavaPath)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
@@ -13,4 +13,9 @@ class OracleJdkIT {
     fun shouldGatherThreadDump() {
         ThreadDumpTest(OracleJDK()).shouldGatherThreadDump()
     }
+
+    @Test
+    fun shouldHaveJavaHomeSet() {
+        JdkSupport(OpenJDK()).shouldHaveJavaHomeSet("/jdk1.8.0_131")
+    }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/OracleJdkIT.kt
@@ -16,6 +16,6 @@ class OracleJdkIT {
 
     @Test
     fun shouldHaveJavaHomeSet() {
-        JdkSupport(OpenJDK()).shouldHaveJavaHomeSet("/jdk1.8.0_131")
+        JdkSupport(OracleJDK()).shouldHaveJavaHomeSet("/jdk1.8.0_131")
     }
 }


### PR DESCRIPTION
- export JAVA_HOME during OracleJDK installation to make it consistent with AdoptOpenJDK(11).
- change the destination file from .bashrc to .profile as the first one can't be sourced using non-interactive shells.
- add tests
- refactor