### PR TITLE
JPERF-1103 Give more time to Jstat.

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/jvm/JstatSupport.kt
@@ -58,6 +58,6 @@ class JstatSupport(
     }
 
     private fun waitForJstatToCollectSomeData() {
-        Thread.sleep(4 * 1000)
+        Thread.sleep(8 * 1000)
     }
 }


### PR DESCRIPTION
Previously 5 builds out of 7 failed. With the fix 5 builds in a row passed, however, there's still another test (MySqlDatabaseIT#shouldStartMysql) that is failing.