### PR TITLE
JPERF-1117: Add FailSafeProfiler and FailSafeProcess to avoid errors …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.25.0...master
 
+### Added
+- Add `FailSafeProfiler`. Fix [JPERF-1117]
+
+[JPERF-1117]: https://ecosystem.atlassian.net/browse/JPERF-1117
+
 ## [4.25.0] - 2023-05-26
 [4.25.0]: https://github.com/atlassian/infrastructure/compare/release-4.24.3...release-4.25.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/FailSafeProfiler.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/FailSafeProfiler.kt
@@ -1,0 +1,43 @@
+package com.atlassian.performance.tools.infrastructure.api.profiler
+
+import com.atlassian.performance.tools.infrastructure.api.process.RemoteMonitoringProcess
+import com.atlassian.performance.tools.ssh.api.SshConnection
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+
+/**
+ * It can be used to wrap [AsyncProfiler] to avoid errors when the profiler fails to stop.
+ */
+class FailSafeProfiler(
+    private val profiler: Profiler
+) : Profiler {
+    override fun install(ssh: SshConnection) {
+        profiler.install(ssh)
+    }
+
+    override fun start(
+        ssh: SshConnection,
+        pid: Int
+    ): RemoteMonitoringProcess? {
+        return profiler.start(ssh, pid)?.let { FailSafeProfilerProcess(it) }
+    }
+
+    private class FailSafeProfilerProcess(
+        private val profilerProcess: RemoteMonitoringProcess
+    ) : RemoteMonitoringProcess {
+        private val logger: Logger = LogManager.getLogger(this::class.java)
+
+        override fun getResultPath(): String {
+            return profilerProcess.getResultPath()
+        }
+
+        override fun stop(ssh: SshConnection) {
+            try {
+                profilerProcess.stop(ssh)
+            } catch (e: Exception) {
+                logger.warn("Failed to stop profiler process", e)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Add FailSafeProfiler and FailSafeProcess to avoid errors when stopping the profiler process.

Sometimes when the Profiler fails to stop, it prevents from gathering unrelated diagnostics. It can be used as a temporary fix for stopping AsyncProfiler until the problem is not fixed.