### PR TITLE
JPERF-1217: Adapt to new ChromeDriver release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.26.0...master
 
+### Fixed
+- Adapt to new ChromeDriver release process. Fix [JPERF-1217].
+
+[JPERF-1217]: https://ecosystem.atlassian.net/browse/JPERF-1217
+
 ## [4.26.0] - 2023-06-21
 [4.26.0]: https://github.com/atlassian/infrastructure/compare/release-4.25.0...release-4.26.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("com.google.guava:guava:23.6-jre")
     implementation("org.apache.httpcomponents:httpclient:4.5.5")
     implementation("org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.3")
+    implementation("javax.json:javax.json-api:1.1")
     log4j(
         "api",
         "core",

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -2,13 +2,13 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
@@ -21,6 +21,7 @@ commons-codec:commons-codec:1.10
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-exec:1.3

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,13 +2,13 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
@@ -27,6 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,13 +2,13 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
@@ -27,6 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,13 +2,13 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.2
@@ -27,6 +27,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0
 org.apache.commons:commons-compress:1.9

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -1,11 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
 com.atlassian.performance:selenium-js:1.0.1

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -1,11 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
 com.atlassian.performance:selenium-js:1.0.1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,14 +1,14 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,6 +27,7 @@ commons-codec:commons-codec:1.10
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 junit:junit:4.13.2
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -2,14 +2,14 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -32,6 +32,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 junit:junit:4.13.2
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -1,11 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
 com.atlassian.performance:selenium-js:1.0.1

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,14 +2,14 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:concurrency:1.1.2
+com.atlassian.performance.tools:concurrency:1.2.1
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.18.0
-com.atlassian.performance.tools:jira-software-actions:1.4.2
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jira-actions:3.21.1
+com.atlassian.performance.tools:jira-software-actions:1.5.0
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.3.0
 com.atlassian.performance.tools:ssh:2.4.3
-com.atlassian.performance.tools:virtual-users:3.13.2
+com.atlassian.performance.tools:virtual-users:3.14.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -32,6 +32,7 @@ commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1
+javax.json:javax.json-api:1.1
 junit:junit:4.13.2
 net.bytebuddy:byte-buddy:1.8.15
 net.i2p.crypto:eddsa:0.2.0

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromeForTesting.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromeForTesting.kt
@@ -1,0 +1,47 @@
+package com.atlassian.performance.tools.infrastructure
+
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClients
+import java.io.StringReader
+import java.net.URI
+import javax.json.JsonObject
+import javax.json.spi.JsonProvider
+
+/**
+ * https://github.com/GoogleChromeLabs/chrome-for-testing
+ */
+internal object ChromeForTesting {
+    fun getLatestDownloadUri(buildVersion: String): URI {
+        val json = queryJson("https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json")
+        val uri = json.getJsonObject("builds")
+            .getJsonObject(buildVersion)
+            .getDownloadUri("linux64")
+            ?: throw Exception("Failed to find ChromeDriver download version for $buildVersion. Got response: $json")
+        return URI.create(uri)
+    }
+
+    fun getLatestStableDownloadUri(): URI {
+        val json = queryJson("https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json")
+        val uri = json.getJsonObject("channels")
+            .getJsonObject("Stable")
+            .getDownloadUri("linux64")
+            ?: throw Exception("Failed to find stable ChromeDriver download version. Got response: $json")
+        return URI.create(uri)
+    }
+
+    private fun queryJson(uri: String): JsonObject {
+        val response = HttpClients.createDefault().execute(HttpGet(uri))
+        return response.entity.content.bufferedReader().use { it.readText() }.let { parse(it) }
+    }
+
+    private fun parse(json: String) = JsonProvider.provider()
+        .createReaderFactory(null)
+        .createReader(StringReader(json))
+        .readObject()
+
+    private fun JsonObject.getDownloadUri(platform: String) = getJsonObject("downloads")
+        .getJsonArray("chromedriver")
+        .find { it.asJsonObject().getString("platform") == platform }
+        ?.asJsonObject()?.getString("url")
+
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromedriverInstaller.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/ChromedriverInstaller.kt
@@ -2,8 +2,6 @@ package com.atlassian.performance.tools.infrastructure
 
 import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
 import java.net.URI
 import java.time.Duration
 
@@ -13,23 +11,17 @@ internal class ChromedriverInstaller(private val uri: URI) {
             {
                 HttpResource(uri).download(ssh, "chromedriver.zip")
                 Ubuntu().install(ssh, listOf("unzip"))
-                ssh.execute("unzip -n -q chromedriver.zip")
-                ssh.execute("chmod +x chromedriver")
-                ssh.execute("sudo ln -s `pwd`/chromedriver /usr/bin/chromedriver")
+                ssh.execute("unzip -n -q chromedriver.zip -d extraction-dir")
+                val executable = ssh.execute("find `pwd`/extraction-dir -name chromedriver -type f").output.lines().first()
+                if (executable.isBlank()) {
+                    throw Exception("No executable found in extracted ChromeDriver archive")
+                }
+                ssh.execute("chmod +x $executable")
+                ssh.execute("sudo ln -s $executable /usr/bin/chromedriver")
             },
             {
                 Ubuntu().install(ssh, listOf("zip", "libglib2.0-0", "libnss3"), Duration.ofMinutes(2))
             }
         )
-    }
-
-    companion object {
-        fun getLatestVersion(minorVersion: String?): String {
-            val httpclient = HttpClients.createDefault()
-            val versionSuffix = if (minorVersion != null) "_$minorVersion" else "";
-            val get = HttpGet("https://chromedriver.storage.googleapis.com/LATEST_RELEASE$versionSuffix")
-            val response = httpclient.execute(get)
-            return response.entity.content.bufferedReader().use { it.readLine() }
-        }
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/Chrome.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/Chrome.kt
@@ -1,14 +1,13 @@
 package com.atlassian.performance.tools.infrastructure.api.browser
 
+import com.atlassian.performance.tools.infrastructure.ChromeForTesting
 import com.atlassian.performance.tools.infrastructure.ChromedriverInstaller
 import com.atlassian.performance.tools.infrastructure.api.os.Ubuntu
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import java.net.URI
 import java.time.Duration.ofMinutes
 
-
 /**
- * We have no control over the chrome version. We install the latest stable chrome version. It may cause not repeatable builds.
+ * We have no control over the Chrome version. We install the latest stable Chrome version. It may cause not repeatable builds.
  */
 class Chrome : Browser {
     private val ubuntu = Ubuntu()
@@ -17,14 +16,23 @@ class Chrome : Browser {
         ubuntu.addKey(ssh, "78BD65473CB3BD13")
         ubuntu.addRepository(ssh, "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main", "google-chrome")
         Ubuntu().install(ssh, listOf("google-chrome-stable"), ofMinutes(5))
-        val installedMinorVersion = getInstalledMinorVersion(ssh)
+        val installedMinorVersion = getInstalledBuildVersion(ssh)
 
-        val version = ChromedriverInstaller.getLatestVersion(installedMinorVersion)
-        ChromedriverInstaller(URI("https://chromedriver.storage.googleapis.com/$version/chromedriver_linux64.zip")).install(ssh)
-
+        val uri = if (installedMinorVersion != null) {
+            ChromeForTesting.getLatestDownloadUri(installedMinorVersion)
+        } else {
+            ChromeForTesting.getLatestStableDownloadUri()
+        }
+        ChromedriverInstaller(uri).install(ssh)
     }
 
-    private fun getInstalledMinorVersion(ssh: SshConnection): String? {
+    /**
+     * https://chromedriver.chromium.org/downloads/version-selection
+     *
+     * > ChromeDriver uses the same version number scheme as Chrome. See https://www.chromium.org/developers/version-numbers for more details.
+     * > Each version of ChromeDriver supports Chrome with matching major, minor, and build version numbers. For example, ChromeDriver 73.0.3683.20 supports all Chrome versions that start with 73.0.3683.
+     */
+    private fun getInstalledBuildVersion(ssh: SshConnection): String? {
         val versionString = ssh.execute("/usr/bin/google-chrome --version").output
         return Regex("Google Chrome ([0-9]+\\.[0-9]+\\.[0-9]+)\\.[0-9]+").find(versionString)?.groupValues?.getOrNull(1)
     }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/ChromeIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/ChromeIT.kt
@@ -7,7 +7,6 @@ import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Test
 
-
 class ChromeIT {
 
     @Test
@@ -22,7 +21,7 @@ class ChromeIT {
 
                 Assert.assertThat(wasInstalledBefore, Matchers.`is`(false))
                 Assert.assertThat(isInstalledAfter, Matchers.`is`(true))
-                Assert.assertThat(isChromedriverInstalled(connection), Matchers.`is`(true))
+                Assert.assertThat(isChromeDriverInstalled(connection), Matchers.`is`(true))
             }
 
         }
@@ -35,9 +34,9 @@ class ChromeIT {
             .contains("installed")
     }
 
-    private fun isChromedriverInstalled(ssh: SshConnection): Boolean {
+    private fun isChromeDriverInstalled(ssh: SshConnection): Boolean {
         val result = ssh
-            .safeExecute("./chromedriver --version")
+            .safeExecute("chromedriver --version")
         return result.isSuccessful()
             .and(
                 result

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/browser/SshChromium.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/browser/SshChromium.kt
@@ -16,7 +16,7 @@ internal class SshChromium(
     private val chromedriverUri: URI
 ) : Browser {
     override fun start(): CloseableRemoteWebDriver {
-        val chromedriverProcess: DetachedProcess = ssh.startProcess("./chromedriver --whitelisted-ips")
+        val chromedriverProcess: DetachedProcess = ssh.startProcess("chromedriver --whitelisted-ips")
 
         val chromeOptions = ChromeOptions()
             .apply { addArguments("--headless") }
@@ -44,7 +44,7 @@ internal class SshChromium(
         ssh.safeExecute("ps aux")
             .output
             .split("\n")
-            .filter { it.contains("./chromedriver --whitelisted-ips") }
+            .filter { it.contains("chromedriver --whitelisted-ips") }
             .single { it.length < 100 }
     }
 }


### PR DESCRIPTION
With ChromeDriver version 115 the maintainers are no longer updating old registry and download infrastructure of ChromeDriver artifacts.

Our tests started to use Chrome 115, but the endpoints we were using didn't report compatible ChromeDriver version, so our code started to fail. See [JPERF-1217].

The new API is based on JSON artifacts available though googlechromelabs.github.io.

See: https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE/m/5NxzS_SRAgAJ

[JPERF-1217]: https://ecosystem.atlassian.net/browse/JPERF-1217