### PR TITLE
Mark 4.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,14 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.27.0...master
+[Unreleased]: https://github.com/atlassian/infrastructure/compare/release-4.28.0...master
+
+## [4.28.0] - 2023-10-11
+[4.28.0]: https://github.com/atlassian/infrastructure/compare/release-4.27.0...release-4.28.0
 
 ### Added
 - Add `AsyncProfiler.Builder` options:
-  - `.output` to aid in investigation of [JPERF-1390]
+  - `output` to aid in investigation of [JPERF-1390]
   - `jfr` and `flamegraph` for convenience
   - `startParams` and `stopParams` for extensibility
 

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/os/Ubuntu.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/os/Ubuntu.kt
@@ -98,6 +98,9 @@ class Ubuntu {
         }
     }
 
+    /**
+     * @since 4.27.0
+     */
     fun addRemoteKey(
         ssh: SshConnection,
         keyUrl: String

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/AsyncProfiler.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/profiler/AsyncProfiler.kt
@@ -58,6 +58,9 @@ class AsyncProfiler private constructor(
         }
     }
 
+    /**
+     * @since 4.27.0
+     */
     class Builder {
 
         private var outputFormat: String = "flamegraph"
@@ -72,14 +75,21 @@ class AsyncProfiler private constructor(
          *
          * @param outputFormat -o
          * @param outputFile -f
+         * @since 4.28.0
          */
         fun output(outputFormat: String, outputFile: String) = apply {
             this.outputFormat = outputFormat
             this.outputFile = outputFile
         }
 
+        /**
+         * @since 4.28.0
+         */
         fun jfr(outputFile: String) = output("jfr", outputFile)
 
+        /**
+         * @since 4.28.0
+         */
         fun flamegraph(outputFile: String) = output("flamegraph", outputFile)
 
         fun wallClockMode() = apply {
@@ -99,10 +109,16 @@ class AsyncProfiler private constructor(
         @Deprecated("use startParams instead", ReplaceWith("startParams(extraParams)"))
         fun extraParams(vararg extraParams: String) = startParams(*extraParams)
 
+        /**
+         * @since 4.28.0
+         */
         fun startParams(vararg startParams: String) = apply {
             this.startParams.addAll(startParams)
         }
 
+        /**
+         * @since 4.28.0
+         */
         fun stopParams(vararg stopParams: String) = apply {
             this.stopParams.addAll(stopParams)
         }


### PR DESCRIPTION
https://packages.atlassian.com/maven-central/com/atlassian/performance/tools/infrastructure/4.28.0/

Also mark `@since` for 4.27.0.