### PR TITLE
JSEC-7320: remove obsolete s3 bucket addresses and mark version-speci…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         arguments: build
     - name: Upload test reports
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-reports
         path: build/reports/tests

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69.kt
@@ -1,23 +1,16 @@
 package com.atlassian.performance.tools.infrastructure.api.browser.chromium
 
-import com.atlassian.performance.tools.infrastructure.ChromedriverInstaller
-import com.atlassian.performance.tools.infrastructure.ChromiumInstaller
 import com.atlassian.performance.tools.infrastructure.api.browser.Browser
-import com.atlassian.performance.tools.infrastructure.ParallelExecutor
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import java.net.URI
 
+@Deprecated("Use CustomChromium")
 class Chromium69 : Browser {
-    private val chromiumUri = URI("https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F576753%2Fchrome-linux.zip?generation=1532051976706023&alt=media")
-    private val chromedriverUri = URI("https://s3.eu-central-1.amazonaws.com/jpt-chromedriver/2.43/chromedriver.zip")
-
     /**
      * Installs chromium 69 with a compatible chromedriver.
      */
     override fun install(ssh: SshConnection) {
-        ParallelExecutor().execute(
-            { ChromiumInstaller(chromiumUri).install(ssh) },
-            { ChromedriverInstaller(chromedriverUri).install(ssh) }
-        )
+        throw IllegalStateException("${this.javaClass} is no longer supported. " +
+            "Please use com/atlassian/performance/tools/infrastructure/api/browser/chromium/CustomChromium.kt instead " +
+            "with explicitly provided Chromium and Chrome Driver URIs.")
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium70.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium70.kt
@@ -1,23 +1,16 @@
 package com.atlassian.performance.tools.infrastructure.api.browser.chromium
 
-import com.atlassian.performance.tools.infrastructure.ChromedriverInstaller
-import com.atlassian.performance.tools.infrastructure.ChromiumInstaller
-import com.atlassian.performance.tools.infrastructure.ParallelExecutor
 import com.atlassian.performance.tools.infrastructure.api.browser.Browser
 import com.atlassian.performance.tools.ssh.api.SshConnection
-import java.net.URI
 
+@Deprecated("Use CustomChromium")
 class Chromium70 : Browser {
-    private val chromiumUri = URI("https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F587811%2Fchrome-linux.zip?generation=1535668921668411&alt=media")
-    private val chromedriverUri = URI("https://s3.eu-central-1.amazonaws.com/jpt-chromedriver/2.43/chromedriver.zip")
-
     /**
      * Installs chromium 70 with a compatible chromedriver.
      */
     override fun install(ssh: SshConnection) {
-        ParallelExecutor().execute(
-            { ChromiumInstaller(chromiumUri).install(ssh) },
-            { ChromedriverInstaller(chromedriverUri).install(ssh) }
-        )
+        throw IllegalStateException("${this.javaClass} is no longer supported. " +
+            "Please use com/atlassian/performance/tools/infrastructure/api/browser/chromium/CustomChromium.kt instead " +
+            "with explicitly provided Chromium and Chrome Driver URIs.")
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium69IT.kt
@@ -1,43 +1,30 @@
 package com.atlassian.performance.tools.infrastructure.api.browser.chromium
 
 import com.atlassian.performance.tools.infrastructure.toSsh
-import com.atlassian.performance.tools.jvmtasks.api.IdempotentAction
-import com.atlassian.performance.tools.jvmtasks.api.StaticBackoff
-import com.atlassian.performance.tools.ssh.api.SshConnection
 import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
 import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Test
-import java.time.Duration
 
 class Chromium69IT {
 
     @Test
-    fun shouldInstallBrowser() {
+    fun shouldThrowUnsupportedError() {
         SshUbuntuContainer.Builder().build().start().use { sshUbuntu ->
             sshUbuntu.toSsh().newConnection().use { connection ->
-                val installedBefore = isChromiumInstalled(connection)
+                val exception = Assert.assertThrows(IllegalStateException::class.java) {
+                    Chromium69().install(connection)
+                }
 
-                Chromium69().install(connection)
-
-                val installedAfter = IdempotentAction("Find Chromium") {
-                    isChromiumInstalled(connection)
-                }.retry(maxAttempts = 2, backoff = StaticBackoff(Duration.ofSeconds(1)))
-
-                Assert.assertThat(installedBefore, Matchers.`is`(false))
-                Assert.assertThat(installedAfter, Matchers.`is`(true))
+                Assert.assertThat(
+                    exception.message,
+                    Matchers.containsString("is no longer supported")
+                )
+                Assert.assertThat(
+                    exception.message,
+                    Matchers.containsString("CustomChromium")
+                )
             }
         }
-    }
-
-    private fun isChromiumInstalled(ssh: SshConnection): Boolean {
-        val result = ssh
-            .safeExecute("ls -lh /usr/bin/chrome")
-        return result.isSuccessful()
-            .and(
-                result
-                    .output
-                    .contains("/root/chrome-linux/chrome")
-            )
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium70IT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/infrastructure/api/browser/chromium/Chromium70IT.kt
@@ -1,11 +1,30 @@
 package com.atlassian.performance.tools.infrastructure.api.browser.chromium
 
+import com.atlassian.performance.tools.infrastructure.toSsh
+import com.atlassian.performance.tools.sshubuntu.api.SshUbuntuContainer
+import org.hamcrest.Matchers
+import org.junit.Assert
 import org.junit.Test
 
 class Chromium70IT {
 
     @Test
-    fun shouldRecoverFromPageLoadTimeout() {
-        PageLoadTimeoutRecoveryTest().run(Chromium70())
+    fun shouldThrowUnsupportedError() {
+        SshUbuntuContainer.Builder().build().start().use { sshUbuntu ->
+            sshUbuntu.toSsh().newConnection().use { connection ->
+                val exception = Assert.assertThrows(IllegalStateException::class.java) {
+                    Chromium70().install(connection)
+                }
+
+                Assert.assertThat(
+                    exception.message,
+                    Matchers.containsString("is no longer supported")
+                )
+                Assert.assertThat(
+                    exception.message,
+                    Matchers.containsString("CustomChromium")
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
The s3 buckets in the version-specific Chromium implementations no longer exist.
This PR removes those links and marks those chromium implementations as deprecated, as the generic, custom one should be used instead.